### PR TITLE
Add ffmpeg dep

### DIFF
--- a/packages.rb
+++ b/packages.rb
@@ -59,6 +59,8 @@ dep 'django.pip'
 
 dep 'django-tagging.pip'
 
+dep 'ffmpeg.bin'
+
 dep 'git-smart.gem' do
   provides %w[git-smart-log git-smart-merge git-smart-pull]
 end

--- a/tc.rb
+++ b/tc.rb
@@ -110,6 +110,7 @@ dep 'tc common packages' do
     'imagemagick.bin', # for paperclip
     'libxml.lib', # for nokogiri
     'libxslt.lib', # for nokogiri
-    'sox.bin' # for audio processing
+    'sox.bin', # for audio processing
+    'ffmpeg.bin' # for audio processing
   ]
 end


### PR DESCRIPTION
While specing the audio processing I found out Sox only reads MPEG-1 by default (MP3), but not MPEG-4 (M4A) because default support for ffmpeg was dropped last year. In order to support anything other MP3, Sox can still be piped through ffmpeg but it needs to be installed separately.
