### PR TITLE
Remove SHAREJS_HOST env variable

### DIFF
--- a/tc.rb
+++ b/tc.rb
@@ -6,9 +6,7 @@ dep 'tc system', :app_user, :key, :env do
   ]
 end
 
-dep 'tc env vars set', :domain do
-  requires 'env var set'.with('SHAREJS_HOST', "https://#{domain}/sharejs")
-end
+dep 'tc env vars set', :domain
 
 dep 'tc app', :env, :host, :domain, :app_user, :app_root, :key do
   def db_name


### PR DESCRIPTION
This var isn't doing anything in production or staging because it's the same value as in `application.yml` in TC.
