### PR TITLE
Refactor 'host provisioned' / met?

### DIFF
--- a/provision.rb
+++ b/provision.rb
@@ -169,7 +169,7 @@ dep 'host provisioned', :host, :host_name, :ref, :env, :app_name, :app_user, :do
     when :down
       false
     when :non_200, :expected_content_missing
-      @should_confirm = true
+      @confirm_beforehand = true
       false
     when :ok
       @run || log_warn("The app seems to be up; babushkaing anyway. (How bad could it be?)")
@@ -177,7 +177,7 @@ dep 'host provisioned', :host, :host_name, :ref, :env, :app_name, :app_user, :do
   }
 
   prepare {
-    unmeetable! "OK, bailing." if @should_confirm && !confirm("Sure you want to provision #{domain} on #{host}?")
+    unmeetable! "OK, bailing." if @confirm_beforehand && !confirm("Sure you want to provision #{domain} on #{host}?")
   }
 
   requires_when_unmet 'public key in place'.with(host, keys)


### PR DESCRIPTION
The main functional change here is that the `expected_content` check is optional now. We only really use it for the main app cause it's a nice extra check; for everything else, the health checks all hit the DB now so they're robust enough to use alone.

It also makes the logic clearer and easier to change in future.