### PR TITLE
Simplify puma upstart template

### DIFF
--- a/puma/puma.init.erb
+++ b/puma/puma.init.erb
@@ -11,7 +11,8 @@ chdir <%=app_root%>
 setuid <%=user%>
 console log
 env LANG=en_AU.UTF-8
+env RACK_ENV=<%=env%>
 
 script
-  /usr/local/bin/bundle exec puma -C config/puma.rb -e <%=env%>
+  ./bin/puma
 end script


### PR DESCRIPTION
This PR attempts to simplify the puma upstart template.

- Our gems are bundled with binstubs so the puma binstub is available at `./bin/puma`.
- The puma config is by default located at `./config/puma.rb`, there's no need to specify it.
- The environment is automatically picked up as long as the `RACK_ENV` variable is set.