### PR TITLE
Fix bug in "ruby app server" dep

### DIFF
--- a/rack.rb
+++ b/rack.rb
@@ -2,14 +2,14 @@ dep 'rails app', :app_name, :env, :domain, :username, :path, :listen_host, :list
   requires [
     'rack app'.with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port, nginx_prefix),
     'common:assets precompiled'.with(env: env, path: path),
-    'config ruby app server'.with(path, env, username)
+    'config ruby app server'.with(app_name, path, env, username)
   ]
 end
 
 dep 'sinatra app', :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port, :nginx_prefix do
   requires [
     'rack app'.with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port, nginx_prefix),
-    'config ruby app server'.with(path, env, username)
+    'config ruby app server'.with(app_name, path, env, username)
   ]
 end
 
@@ -27,7 +27,7 @@ dep 'rack app', :app_name, :env, :domain, :username, :path, :listen_host, :liste
   ]
 end
 
-dep 'config ruby app server', :path, :env, :username do
+dep 'config ruby app server', :app_name, :path, :env, :username do
   def has_unicorn_config?
     "#{path}/config/unicorn.rb".p.exists?
   end


### PR DESCRIPTION
There is a bug in our "ruby app server" dep that prevents it from running. The `app_name` variable is expected, but it is not passed into the dep.

The puma codepath works fine because it doesn't use `app_name`, but the unicorn codepath is broken.