### PR TITLE
Remove unicorn socket logging

### DIFF
--- a/rack.rb
+++ b/rack.rb
@@ -37,13 +37,8 @@ dep 'config ruby app server', :app_name, :path, :env, :username do
   end
 
   if has_unicorn_config?
-    requires [
-      'unicorn upstart config'.with(env, username),
-      'log unicorn socket'.with(app_name, username)
-    ]
+    requires 'unicorn upstart config'.with(env, username)
   elsif has_puma_config?
-    requires [
-      'puma upstart config'.with(env, username),
-    ]
+    requires 'puma upstart config'.with(env, username)
   end
 end

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -51,20 +51,3 @@ dep 'unicorn upstart config', :env, :user do
     sleep 10
   }
 end
-
-dep 'log unicorn socket', :app_name, :user do
-  requires [
-    "script installed".with('socket-statsd-logger'),
-    "socket-statsd-logger.upstart".with(app_name, user)
-  ]
-end
-
-dep 'socket-statsd-logger.upstart', :app_name, :user do
-  respawn 'yes'
-  command "/usr/local/bin/socket-statsd-logger /srv/http/#{user}/current/tmp/sockets/unicorn.socket #{app_name}.unicorn.socket"
-  setuid user
-  chdir "/srv/http/#{user}/current"
-  met? {
-    shell?("ps aux | grep -v grep | grep 'socket-statsd-logger /srv/http/#{user}'")
-  }
-end


### PR DESCRIPTION
It appears that we used to log the number of queued and active connections on the unicorn socket to statsd. I don't believe we're using statsd anymore, so this is just another moving part that we don't need. Can anyone confirm this? /cc @yob @nickbrowne

This PR removes that functionality.