### PR TITLE
Log puma sockets to statsd

### DIFF
--- a/puma.rb
+++ b/puma.rb
@@ -48,3 +48,21 @@ dep 'puma upstart config', :env, :user do
   }
 end
 
+dep 'log puma socket', :app_name, :path, :user  do
+  requires [
+    "script installed".with('socket-statsd-logger'),
+    "puma-socket-statsd-logger.upstart".with(app_name, path, user)
+  ]
+end
+
+dep 'puma-socket-statsd-logger.upstart', :app_name, :path, :user do
+  socket_path = (path / "tmp/sockets/puma.socket").abs
+  respawn 'yes'
+  command "/usr/local/bin/socket-statsd-logger #{socket_path} #{app_name}.#{socket_path.basename}"
+  setuid user
+  chdir path.p.abs
+  met? {
+    shell?("ps aux | grep -v grep | grep 'socket-statsd-logger #{socket_path}'")
+  }
+end
+

--- a/rack.rb
+++ b/rack.rb
@@ -27,23 +27,24 @@ dep 'rack app', :app_name, :env, :domain, :username, :path, :listen_host, :liste
   ]
 end
 
-dep 'config ruby app server', :app_name, :path, :env, :username do
+dep 'config ruby app server', :app_name, :path, :env, :user do
   def has_unicorn_config?
-    "#{path}/config/unicorn.rb".p.exists?
+    (path / "config/unicorn.rb").exists?
   end
 
   def has_puma_config?
-    "#{path}/config/puma.rb".p.exists?
+    (path / "config/puma.rb").exists?
   end
 
   if has_unicorn_config?
     requires [
-      'unicorn upstart config'.with(env, username),
-      'log unicorn socket'.with(app_name, username)
+      'unicorn upstart config'.with(env, user),
+      'log unicorn socket'.with(app_name, path, user)
     ]
   elsif has_puma_config?
     requires [
-      'puma upstart config'.with(env, username),
+      'puma upstart config'.with(env, user),
+      'log puma socket'.with(app_name, path, user)
     ]
   end
 end

--- a/scripts/socket-statsd-logger
+++ b/scripts/socket-statsd-logger
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-# Logs the number of queued and active connections on the unicorn socket to statsd.
-# There's a cap on the number of queued connections. If we hit it then nginx will
-# start serving 504 pages
+# Logs the number of queued and active connections on the unicorn/puma socket to
+# statsd. There's a cap on the number of queued connections. If we hit it then
+# nginx will start serving 504 pages.
 #
-# There is no visible output, but data is sent to statsd each second
+# There is no visible output, but data is sent to statsd each second.
 #
 # Props to Tim Lucas for the basic structure:
 #
@@ -17,7 +17,7 @@
 
 require 'socket'
 
-USAGE = "socket-statsd-logger <path to unicorn socket> <metric name>"
+USAGE = "socket-statsd-logger <path to socket> <metric name>"
 METRIC_NAME_REGEXP = /\A[a-z][a-z\.]+[a-z]\Z/
 
 socket_path, metric_name = *ARGV

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -52,19 +52,20 @@ dep 'unicorn upstart config', :env, :user do
   }
 end
 
-dep 'log unicorn socket', :app_name, :user do
+dep 'log unicorn socket', :app_name, :path, :user  do
   requires [
     "script installed".with('socket-statsd-logger'),
-    "socket-statsd-logger.upstart".with(app_name, user)
+    "unicorn-socket-statsd-logger.upstart".with(app_name, path, user)
   ]
 end
 
-dep 'socket-statsd-logger.upstart', :app_name, :user do
+dep 'unicorn-socket-statsd-logger.upstart', :app_name, :path, :user do
+  socket_path = (path / "tmp/sockets/unicorn.socket").abs
   respawn 'yes'
-  command "/usr/local/bin/socket-statsd-logger /srv/http/#{user}/current/tmp/sockets/unicorn.socket #{app_name}.unicorn.socket"
+  command "/usr/local/bin/socket-statsd-logger #{socket_path} #{app_name}.#{socket_path.basename}"
   setuid user
-  chdir "/srv/http/#{user}/current"
+  chdir path.p.abs
   met? {
-    shell?("ps aux | grep -v grep | grep 'socket-statsd-logger /srv/http/#{user}'")
+    shell?("ps aux | grep -v grep | grep 'socket-statsd-logger #{socket_path}'")
   }
 end


### PR DESCRIPTION
We weren't logging puma socket stats to statsd as we already do for unicorn sockets.

This PR refactors the unicorn socket logging to be general enough to handle both puma and unicorn.