### PR TITLE
Conversation namespace Delayed Job restarted

### DIFF
--- a/delayed_job.rb
+++ b/delayed_job.rb
@@ -22,3 +22,19 @@ dep 'delayed_job.upstart', :env, :user, :queue do
     shell?("ps ux | grep -v grep | grep 'rake jobs:work'")
   }
 end
+
+dep 'delayed job restarted', template: 'task' do
+  run {
+    output = shell?('ps ux | grep -v grep | grep "rake jobs:work"')
+
+    if output.nil?
+      log "`rake jobs:work` isn't running."
+      true
+    else
+      pids = output.scan(/^\S+\s+(\d+)\s+/).flatten
+      pids.each do |pid|
+        log_shell "Sending SIGTERM to #{pid}", "kill -s TERM #{pid}"
+      end
+    end
+  }
+end


### PR DESCRIPTION
Babushka's `common:delayed job restarted` greps only the first worker instance PID. 

This PR creates a `conversation:delayed job restarted` dep (under our namespace) so as to kill all instances matching `rake jobs:work`