### PR TITLE
Set ENV variables inline for delayed job startup

### DIFF
--- a/delayed_job.rb
+++ b/delayed_job.rb
@@ -14,8 +14,7 @@ dep 'delayed_job.upstart', :env, :user, :queue do
     vars << "QUEUES=#{queue}"
   end
 
-  environment vars
-  command "bundle exec rake jobs:work"
+  command "bundle exec rake jobs:work #{vars.join(' ')}"
   setuid user
   chdir "/srv/http/#{user}/current"
   met? {


### PR DESCRIPTION
Previously we pre-define the env variables, which is nice and clean but doesn't offer us the ability to grep by those env variables.

Particularly, QUEUES=... Which we'd grep to confirm that a worker is running for particular queues.