### PR TITLE
Change postgres idle_in_transaction_session_timeout to 1 hour

### DIFF
--- a/postgres/postgresql.conf.erb
+++ b/postgres/postgresql.conf.erb
@@ -32,7 +32,7 @@ lc_numeric = 'en_AU.UTF-8'
 lc_time = 'en_AU.UTF-8'
 default_text_search_config = 'pg_catalog.english'
 
-idle_in_transaction_session_timeout = '120s'
+idle_in_transaction_session_timeout = '1h'
 
 # These settings only apply to the master.
 wal_level = logical


### PR DESCRIPTION
This PR changes the postgres `idle_in_transaction_session_timeout` value to 1 hour (our previous value was 2 minutes).

This setting is used to terminate all idle transactions after a timeout period. It is only really useful if we have idle transactions blocking access to other resources, or say if someone starts a transaction in a psql session and then goes out to lunch.

At the moment the short timeout value is causing problems with long-running migrations and the data warehouse ETL. Specificially, running the topics/taggings ETL from scratch can have more than 2 minutes of idle DB activity becuase the ruby code is scanning through all the early tc-events where we weren't recording topics at all.

I think this setting is useful for us in a general DB house keeping sense – we don't want any stale transactions – but we do need to allow for long-running migrations and other tasks which may have a lot of ruby processing before anything gets written to the DB.

Thoughts?