### PR TITLE
Disable basic auth in nginx for the TC API

### DIFF
--- a/nginx/tc_vhost.common.erb
+++ b/nginx/tc_vhost.common.erb
@@ -60,3 +60,18 @@ location @app {
   proxy_set_header     X-Forwarded-Proto $tc_client_scheme;
   proxy_set_header     X-Request-Start   "t=${msec}";
 }
+
+location /api/ {
+  # Currently the Rails app handles auth for the API.
+  auth_basic off;
+
+  proxy_pass     http://<%= upstream_name %>;
+  proxy_redirect off;
+
+  proxy_set_header Host            $host;
+  proxy_set_header X-Real-IP       $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+  client_max_body_size 10m;
+  proxy_buffers        4 32k;
+}


### PR DESCRIPTION
This PR disables basic auth for the TC API. Currently, authentication doesn't work on Analytics (staging) because there are two levels of basic auth for the TC (staging) API:

1. The TC (staging) app is protected by basic auth, configured in the nginx vhost config.
2. The TC (staging) API is also protected by basic auth, configured in the TC rails app.

When Analytics (staging) tries to hit the TC (staging) API to get the current user, the request fails because only once set of credentials is provided (I'm not even sure if it's possible to authenticate against two basic auths).

The simplest solution is to disable basic auth for the TC API in the nginx vhost config. I think ultimately all basic auth should be configured in nginx (and never in rails), but that's a story for another PR.

If you want to test it out on staging (these changes are currently applied). You just have to look up the password from our `settings.yml` file:

    curl --basic -u tcdonations:password "https://tc.tc-dev.net/api/v1/users/3937.json"