### PR TITLE
Simplify two deps

### DIFF
--- a/counter.rb
+++ b/counter.rb
@@ -36,8 +36,7 @@ dep 'counter packages' do
     'counter common packages',
     'curl.lib',
     'running.nginx',
-    'socat.bin', # for DB tunnelling
-    'geoipupdate.bin' # for keeping maxmind geo databases up to date
+    'socat.bin' # for DB tunnelling
   ]
 end
 

--- a/packages.rb
+++ b/packages.rb
@@ -163,25 +163,8 @@ dep 'rcconf.bin' do
   requires 'whiptail.bin'
 end
 
-dep 's3cmd' do
-  requires "python-dateutil.lib"
-
- def source_url
-   "http://mirrors.kernel.org/ubuntu/pool/universe/s/s3cmd/s3cmd_1.5.0~rc1-2_all.deb"
- end
-
- met? {
-   log_shell("checking for s3cmd", "which s3cmd")
- }
- meet {
-   if Babushka.host.linux?
-     Babushka::Resource.get(source_url) { |path|
-       log_shell("installing s3cmd", "dpkg -i #{path}", :sudo => true)
-     }
-   else
-     unmeetable! "Not sure how to install s3cmd on this system."
-   end
- }
+dep 's3cmd.bin' do
+  requires 'whiptail.bin'
 end
 
 dep 'sasl.lib' do

--- a/packages.rb
+++ b/packages.rb
@@ -60,25 +60,6 @@ dep 'fastly.gem' do
   provides []
 end
 
-# Once we're using Ubuntu 16.04 in production, we can simplify this dep to just:
-#
-#  dep "geoipupdate.bin"
-dep 'geoipupdate.bin', :version do
-  requires_when_unmet {
-    on :apt, 'keyed apt source'.with(
-      :uri => 'http://ppa.launchpad.net/maxmind/ppa/ubuntu',
-      :release => 'trusty',
-      :repo => 'main',
-      :key_sig => 'DE742AFA',
-      :key_uri => 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xDE1997DCDE742AFA'
-    )
-  }
-  installs {
-    via :apt, "geoipupdate"
-    via :brew, "geoipupdate"
-  }
-end
-
 dep 'git-smart.gem' do
   provides %w[git-smart-log git-smart-merge git-smart-pull]
 end

--- a/system.rb
+++ b/system.rb
@@ -13,7 +13,7 @@ dep 'core software' do
     'tree.bin',
     'pv.bin',
     'ntpd.bin',
-    's3cmd',
+    's3cmd.bin',
     'trickle.bin'
   ]
 end


### PR DESCRIPTION
I was reviewing `packages.rb` ahead of the upgrade to Ubuntu 16.04 and noticed two simplifications:

* The `geoipupdate.bin` dep isn't needed anymore
* The artisanal `s3cmd` can be replaced with a regular install via apt

See the individual commits for more details.