### PR TITLE
Remove ntpd

### DIFF
--- a/collectd/30_ntpd.conf.erb
+++ b/collectd/30_ntpd.conf.erb
@@ -1,6 +1,0 @@
-<Plugin ntpd>
-	Host "localhost"
-	Port 123
-#	ReverseLookups false
-#	IncludeUnitID true
-</Plugin>

--- a/collectd/collectd.conf.erb
+++ b/collectd/collectd.conf.erb
@@ -38,7 +38,6 @@ LoadPlugin interface
 LoadPlugin load
 LoadPlugin memcached
 LoadPlugin memory
-LoadPlugin ntpd
 LoadPlugin processes
 LoadPlugin statsd
 LoadPlugin swap

--- a/packages.rb
+++ b/packages.rb
@@ -108,10 +108,6 @@ dep 'nc.bin'
 
 dep 'nmap.bin'
 
-dep 'ntpd.bin' do
-  installs { via :apt, 'ntp' }
-end
-
 dep 'pcre.lib' do
   installs 'libpcre3-dev'
 end

--- a/system.rb
+++ b/system.rb
@@ -15,7 +15,6 @@ dep 'core software' do
     'nmap.bin',
     'tree.bin',
     'pv.bin',
-    'ntpd.bin',
     's3cmd.bin',
     'trickle.bin'
   ]
@@ -74,7 +73,6 @@ dep 'monitored with collectd', :librato_user, :librato_password do
       "collectd/30_interface.conf.erb" => "/etc/collectd/collectd.conf.d/30_interface.conf",
       "collectd/30_load.conf.erb" => "/etc/collectd/collectd.conf.d/30_load.conf",
       "collectd/30_memcached.conf.erb" => "/etc/collectd/collectd.conf.d/30_memcached.conf",
-      "collectd/30_ntpd.conf.erb" => "/etc/collectd/collectd.conf.d/30_ntpd.conf",
       "collectd/30_processes.conf.erb" => "/etc/collectd/collectd.conf.d/30_processes.conf",
       "collectd/30_statsd.conf.erb" => "/etc/collectd/collectd.conf.d/30_statsd.conf",
       "collectd/30_swap.conf.erb" => "/etc/collectd/collectd.conf.d/30_swap.conf",


### PR DESCRIPTION
This PR removes ntpd from our servers.

Ubuntu 16.04 has its own time syncing via the timedatectl tool. Unfortunately, ntpd conflicts with this service so you can't run both at once. I've opted to go with the time syncing that ships with Ubuntu and remove ntpd. This way *all* of our infrastructure (including CI) will be running the same time syncing.

One caveat was that our collectd config relies on having a ntp server locally, so I have removed this from our collecd configuration also.