### PR TITLE
Override 'app bundled' dep to ignore binstubs

### DIFF
--- a/bundler.rb
+++ b/bundler.rb
@@ -1,0 +1,21 @@
+# This dep overrides `common:app bundled` to ensure bundler is run with the
+# `--no-binstubs` flag.
+dep 'app bundled', :root, :env do
+  requires_when_unmet Dep('current dir:packages')
+  met? {
+    if !(root / 'Gemfile').exists?
+      log "No Gemfile - skipping bundling."
+      true
+    else
+      shell? 'bundle check', :cd => root, :log => true
+    end
+  }
+  meet {
+    install_args = %w[development test].include?(env) ? '' : "--deployment --no-binstubs --without 'development test'"
+    unless shell("bundle install #{install_args} | grep -v '^Using '", :cd => root, :log => true)
+      confirm("Try a `bundle update`", :default => 'n') {
+        shell 'bundle update', :cd => root, :log => true
+      }
+    end
+  }
+end

--- a/db.rb
+++ b/db.rb
@@ -7,7 +7,7 @@ dep 'db', :username, :root, :env, :data_required, :require_db_deps do
 
   require_db_deps.default!('yes')
 
-  requires 'common:app bundled'.with(root, env)
+  requires 'app bundled'.with(root, env)
 
   if require_db_deps[/^y/]
     if data_required[/^y/]

--- a/deploy.rb
+++ b/deploy.rb
@@ -78,7 +78,7 @@ dep 'cache cleared' do
 end
 
 dep 'marked on newrelic.task', :ref, :env do
-  requires 'common:app bundled'.with('.', 'development')
+  requires 'app bundled'.with('.', 'development')
   run {
     # Some of our apps store the newrelic config file in a template that is copied]
     # into position in production.
@@ -95,7 +95,7 @@ dep 'marked on newrelic.task', :ref, :env do
 end
 
 dep 'marked on bugsnag.task', :ref, :env do
-  requires 'common:app bundled'.with('.', 'development')
+  requires 'app bundled'.with('.', 'development')
   run {
     if 'config/initializers/bugsnag.rb'.p.exists?
       log_shell "Notifying bugsnag", "bundle exec rake bugsnag:deploy BUGSNAG_REVISION=#{shell("git rev-parse --short #{ref}")} BUGSNAG_RELEASE_STAGE=#{env}"

--- a/rack.rb
+++ b/rack.rb
@@ -32,7 +32,7 @@ dep 'rack app', :app_name, :env, :domain, :username, :path, :listen_host, :liste
 
   requires [
     'user exists'.with(username, '/srv/http'),
-    'common:app bundled'.with(path, env),
+    'app bundled'.with(path, env),
     'vhost enabled.nginx'.with(app_name, env, domain, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
     'rack.logrotate'.with(username),
     'running.nginx'


### PR DESCRIPTION
This PR overrides the 'common:app bundled' dep to ensure we pass `--no-binstubs` when bundling.

We currently have a problem where our apps are always bundling with binstubs on staging/prod. The binstubs override existing files in the repo and cause issues when we try to deploy to a dirty repo.