### PR TITLE
our systems now require Indonesian dictionaries for aspell

### DIFF
--- a/packages.rb
+++ b/packages.rb
@@ -7,7 +7,7 @@ dep 'aspell.bin'
 dep 'aspell dictionary.lib' do
   requires 'aspell.bin'
   installs {
-    on :linux, 'aspell-en', 'aspell-fr', 'libaspell-dev'
+    on :linux, 'aspell-en', 'aspell-fr', 'aspell-id', 'libaspell-dev'
     otherwise []
   }
 end


### PR DESCRIPTION
We're preparing to add Indonesian support to our spell checker, which relies on aspell