### PR TITLE
Configure postfix to use mailgun for delivering mail

### DIFF
--- a/postfix.rb
+++ b/postfix.rb
@@ -23,6 +23,7 @@ meta :postfix do
 end
 
 dep 'postfix.bin'
+dep 'mailutils.bin'
 
 dep 'running.postfix' do
   requires 'configured.postfix'
@@ -47,10 +48,13 @@ dep 'configured.postfix', :mailgun_password do
   end
 
   requires 'postfix.bin'
+  requires 'mailutils.bin'
+
   met? {
     Babushka::Renderable.new(postfix_conf).from?(dependency.load_path.parent / "postfix/main.cf.erb")
     Babushka::Renderable.new(sasl_passwd).from?(dependency.load_path.parent / "postfix/sasl_passwd.erb")
   }
+
   meet {
     render_erb 'postfix/main.cf.erb', to: postfix_conf
     render_erb 'postfix/sasl_passwd.erb', to: sasl_passwd

--- a/postfix.rb
+++ b/postfix.rb
@@ -3,21 +3,28 @@ meta :postfix do
     "/etc/postfix/main.cf"
   end
 
+  def sasl_passwd
+    "/etc/postfix/sasl_passwd"
+  end
+
+  def start_postfix
+    log_shell "Starting postfix...", "systemctl start postfix"
+  end
+
   def restart_postfix
     if postfix_running?
-      log_shell "restarting postfix", "/etc/init.d/postfix restart"
+      log_shell "Restarting postfix...", "systemctl restart postfix"
     end
   end
 
   def postfix_running?
-    shell? "netstat -an | grep -E '^tcp.*[.:]25 +.*LISTEN'"
+    shell? "systemctl is-active postfix"
   end
 end
 
 dep 'postfix.bin'
 
 dep 'running.postfix' do
-
   requires 'configured.postfix'
 
   met? {
@@ -27,14 +34,14 @@ dep 'running.postfix' do
   }
 
   meet :on => :linux do
-    shell '/etc/init.d/postfix start'
+    start_postfix
   end
   meet :on => :osx do
     log_error "launchctl should have already started postfix. Check /var/log/system.log for errors."
   end
 end
 
-dep 'configured.postfix' do
+dep 'configured.postfix', :mailgun_password do
   def hostname
     shell('hostname -f').chomp
   end
@@ -42,9 +49,13 @@ dep 'configured.postfix' do
   requires 'postfix.bin'
   met? {
     Babushka::Renderable.new(postfix_conf).from?(dependency.load_path.parent / "postfix/main.cf.erb")
+    Babushka::Renderable.new(sasl_passwd).from?(dependency.load_path.parent / "postfix/sasl_passwd.erb")
   }
   meet {
-    render_erb 'postfix/main.cf.erb', :to => postfix_conf
+    render_erb 'postfix/main.cf.erb', to: postfix_conf
+    render_erb 'postfix/sasl_passwd.erb', to: sasl_passwd
+    shell 'chmod 600 /etc/postfix/sasl_passwd'
+    shell 'postmap /etc/postfix/sasl_passwd'
   }
 
   after { restart_postfix }

--- a/postfix/main.cf.erb
+++ b/postfix/main.cf.erb
@@ -7,7 +7,7 @@ alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 myorigin = /etc/mailname
 mydestination = <%= hostname%>, localhost
-relayhost =
+relayhost = smtp.mailgun.org
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
@@ -15,3 +15,6 @@ inet_interfaces = 127.0.0.1
 default_transport = smtp
 relay_transport = smtp
 inet_protocols = ipv4
+smtp_sasl_auth_enable = yes
+smtp_sasl_security_options = noanonymous
+smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd

--- a/postfix/sasl_passwd.erb
+++ b/postfix/sasl_passwd.erb
@@ -1,0 +1,1 @@
+smtp.mailgun.org postmaster@tc-dev.net:<%= mailgun_password %>


### PR DESCRIPTION
This PR configures postfix to use mailgun for delivering mail.

This was previously configured by hand and caused some issues when we reinstalled our machines and email wasn't working.

I used this [article](https://community.rackspace.com/products/f/28/t/63) for the mailgun specifics.