### PR TITLE
Bind puma to unix socket in systemd service

### DIFF
--- a/puma.rb
+++ b/puma.rb
@@ -6,7 +6,10 @@ dep 'puma.systemd', :env, :path, :username, :threads, :workers do
   respawn 'yes'
   pid_file (path / 'tmp/pids/puma.pid').abs
 
-  command (path / 'bin/puma').abs
+  puma = (path / 'bin/puma').abs
+  socket_path = (path / "tmp/sockets/puma.socket").abs
+  command "#{puma} -b unix://#{socket_path}"
+
   reload_command "/bin/kill -s USR1 $MAINPID" # reload workers
 
   setuid username


### PR DESCRIPTION
This PR updates the puma systemd service to bind puma to a UNIX socket.

We only ever use UNIX sockets in staging/production.

Configuring this in the service, rather than in each of our apps, means that we don't need to introduce more conditional logic into the `config/puma.rb` file if we want to move to docker. This is because our dockerised apps rely on TCP sockets (which are the puma default), instead of UNIX sockets.

This change will allow us to remove the `bind` statement in the `config/puma.rb file`. The configuration for each of our apps running puma is virtually identical:

```ruby
...
unless ENV["RACK_ENV"] == "development"
  bind "unix://#{path}/tmp/sockets/puma.socket"
end
```