### PR TITLE
Specify puma CLI options

### DIFF
--- a/puma.rb
+++ b/puma.rb
@@ -8,12 +8,12 @@ dep 'puma.systemd', :env, :path, :username, :threads, :workers do
 
   puma_path = (path / 'bin/puma').abs
   socket_path = (path / "tmp/sockets/puma.socket").abs
-  command "#{puma_path} -b 'unix://#{socket_path}'"
+  command "#{puma_path} -b 'unix://#{socket_path}' -t #{threads} -w #{workers}"
   reload_command "/bin/kill -s USR1 $MAINPID" # reload workers
 
   setuid username
   chdir path.p.abs
-  environment "APP_ENV=#{env}", "RACK_ENV=#{env}", "RAILS_ENV=#{env}", "PUMA_THREADS=#{threads}", "PUMA_WORKERS=#{workers}"
+  environment "APP_ENV=#{env}", "RACK_ENV=#{env}", "RAILS_ENV=#{env}"
 end
 
 dep 'log puma socket', :app_name, :path, :user  do

--- a/puma.rb
+++ b/puma.rb
@@ -6,7 +6,9 @@ dep 'puma.systemd', :env, :path, :username, :threads, :workers do
   respawn 'yes'
   pid_file (path / 'tmp/pids/puma.pid').abs
 
-  command (path / 'bin/puma').abs
+  puma_path = (path / 'bin/puma').abs
+  socket_path = (path / "tmp/sockets/puma.socket").abs
+  command "#{puma_path} -b 'unix://#{socket_path}'"
   reload_command "/bin/kill -s USR1 $MAINPID" # reload workers
 
   setuid username


### PR DESCRIPTION
This PR updates our `puma.systemd` dep to specify puma options using CLI args, rather than use environment variables.

When I originally added puma I wrote our config files using the examples provided on Heroku. They use environment variables because with Heroku that is your only option.

The puma binary actually supports all these options as switches, so there is no need to add all this extra code in the `config/puma.rb` file just to handle environment variables.

Using the CLI switches, we are now explicitly specifying the puma listening socket as a UNIX socket. This means that any environment other than production will listen on a TCP socket by default.