### PR TITLE
update ruby on ci+prod to 2.3.4

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -21,7 +21,7 @@ end
 dep 'ci prepared' do
   requires [
     'common:set.locale'.with(:locale_name => 'en_AU'),
-    'ruby.src'.with(:version => '2.3.3', :patchlevel => 'p222'),
+    'ruby.src'.with(:version => '2.3.4', :patchlevel => 'p301'),
   ]
 end
 

--- a/provision.rb
+++ b/provision.rb
@@ -198,7 +198,7 @@ dep 'host provisioned', :host, :host_name, :ref, :env, :app_name, :app_user, :do
       remote_babushka 'common:set.locale', :locale_name => 'en_AU'
 
       # Build ruby separately, because it changes the ruby binary for subsequent deps.
-      remote_babushka 'conversation:ruby.src', :version => '2.3.3', :patchlevel => 'p222'
+      remote_babushka 'conversation:ruby.src', :version => '2.3.4', :patchlevel => 'p301'
 
       # All the system-wide config for this app, like packages and user accounts.
       remote_babushka "conversation:system provisioned", :host_name => host_name, :env => env, :app_name => app_name, :app_user => app_user, :key => keys


### PR DESCRIPTION
This is a tiny bump from 2.3.3, so I'm not expecting any surprises.

We've recently been getting occasional segfaults in our builds, and the changelog for this claims to fix a few. Maybe we'll get lucky and have our issue resolved?

Roll out plan:

1. Update CI and trigger a build for each app
2. Update staging and restart unicorn or puma for each app
3. Update prod-lon and restart unicorn or puma for each app
4. Update prod-dal and restart unicorn or puma for each app