### PR TITLE
Update collectd config format

### DIFF
--- a/collectd/10_write_http.conf.erb
+++ b/collectd/10_write_http.conf.erb
@@ -1,7 +1,8 @@
 <Plugin write_http>
-  <URL "https://collectd.librato.com/v1/measurements">
+  <Node "librato">
+    URL "https://collectd.librato.com/v1/measurements"
     User "<%= librato_user %>"
     Password "<%= librato_password %>"
     Format "JSON"
-  </URL>
+  </Node>
 </Plugin>


### PR DESCRIPTION
This PR updates the Librato configuration in our collectd config.

I noticed that we're using the old format, the Librato documentation states:

```
For collectd 5.5.0 and newer, add the following snippet:

<Plugin write_http>
  <Node "librato">
    URL "https://collectd.librato.com/v1/measurements"
    User "user"
    Password "secret"
    Format "JSON"
  </Node>
</Plugin>
```