### PR TITLE
Increase analytics puma threads from 4 to 8

### DIFF
--- a/analytics.rb
+++ b/analytics.rb
@@ -26,7 +26,8 @@ dep 'analytics app', :env, :host, :domain, :app_user, :app_root, :key do
       :listen_host => host,
       :domain => domain,
       :username => app_user,
-      :path => app_root
+      :path => app_root,
+      :threads => 8
     )
   ]
 end


### PR DESCRIPTION
The PR bumps the running puma threads to 8 (I suspect we should go even higher).

Analytics provides a JSON API to its front-end javascript. This API wraps multiple requests to the data warehouse, some of which can take a fair while to complete. These long-running requests will starve the puma workers and we see an increase in requests queuing time in New Relic. By having more threads we can serve more requests, even if some of them get tied up waiting on slow IO.