### PR TITLE
Add counter.theconversation.com server alias

### DIFF
--- a/counter.rb
+++ b/counter.rb
@@ -11,7 +11,13 @@ dep 'counter app', :env, :host, :domain, :app_user, :app_root, :key do
   requires [
     'geoip database'.with(:app_root => app_root),
     'ssl cert in place'.with(:domain => domain, :env => env),
+  ]
 
+  if env == 'production'
+    requires 'ssl cert in place'.with(:domain => 'counter.theconversation.com', :env => env)
+  end
+
+  requires [
     'db'.with(
       :env => env,
       :username => app_user,

--- a/nginx/counter_vhost.common.erb
+++ b/nginx/counter_vhost.common.erb
@@ -1,0 +1,33 @@
+charset utf-8;
+
+root <%= path / 'public' %>;
+
+# POSTs are intended for the app, not cached pages. We use '=' to let @app set the response code.
+error_page 405 = @app;
+
+# Respond with the maintenance page whenever the status is 503.
+error_page 503 /system/maintenance.html;
+
+# Serve cached pages if they exist; otherwise, punt the request to the app.
+try_files $uri/index.html $uri.html $uri @app;
+
+location @app {
+  # If the maintenance page exists, then respond with HTTP 503 (which will
+  # serve the maintenace page; see error_page above).
+  if (-f $document_root/system/maintenance.html) {
+    return 503;
+  }
+
+  proxy_pass           http://<%= upstream_name %>;
+  proxy_redirect       off;
+
+  proxy_buffer_size    64k;
+  proxy_buffers        32 16k;
+  client_max_body_size 128m;
+
+  proxy_set_header     Host              $host;
+  proxy_set_header     Client-Ip         $tc_client_ip;
+  proxy_set_header     X-Real-IP         $remote_addr;
+  proxy_set_header     X-Forwarded-Proto $tc_client_scheme;
+  proxy_set_header     X-Request-Start   "t=${msec}";
+}

--- a/nginx/counter_vhost.conf.erb
+++ b/nginx/counter_vhost.conf.erb
@@ -1,1 +1,46 @@
-standard_vhost.conf.erb
+upstream <%= upstream_name %> {
+  # fail_timeout=0 means we always retry the unicorn master, since it's
+  # responsible for restarting workers when they fail.
+  server unix:<%= application_socket %> fail_timeout=0;
+}
+
+# Canonical www. redirect
+server {
+  listen <%= listen_port %>;
+  server_name www.counter.theconversation.edu.au www.counter.theconversation.com;
+  return 301 http://counter.theconversation.com$request_uri;
+}
+
+server {
+  server_name counter.theconversation.edu.au;
+
+  listen <%= listen_port %>;
+
+  listen 443 ssl;
+
+  ssl_certificate      /etc/ssl/certs/counter.theconversation.edu.au.crt;
+  ssl_certificate_key  /etc/ssl/private/counter.theconversation.edu.au.key;
+  ssl_session_timeout  5m;
+  ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers          ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:HIGH:!aNULL:!MD5:!kEDH;
+  ssl_prefer_server_ciphers on;
+
+  include /etc/nginx/sites-available/<%= domain %>.common;
+}
+
+server {
+  server_name counter.theconversation.com;
+
+  listen <%= listen_port %>;
+
+  listen 443 ssl;
+
+  ssl_certificate      /etc/ssl/certs/counter.theconversation.com.crt;
+  ssl_certificate_key  /etc/ssl/private/counter.theconversation.com.key;
+  ssl_session_timeout  5m;
+  ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers          ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:HIGH:!aNULL:!MD5:!kEDH;
+  ssl_prefer_server_ciphers on;
+
+  include /etc/nginx/sites-available/<%= domain %>.common;
+}


### PR DESCRIPTION
Depends on:

- [x] conversation/tc-ops#47
- [x] conversation/tc-counter#185

This PR adds a `counter.theconversation.com` alias to the nginx configuration. This way we can serve requests on both domains while we transition to the `.com` domain.