### PR TITLE
Update TC vhost to try TCP backend first

### DIFF
--- a/nginx/tc_vhost.conf.erb
+++ b/nginx/tc_vhost.conf.erb
@@ -1,8 +1,9 @@
 # The unicorn appserver.
 upstream <%= upstream_name %> {
+  server 127.0.0.1:3000;
   # fail_timeout=0 means we always retry the unicorn master, since it's
   # responsible for restarting workers when they fail.
-  server unix:<%= application_socket %> fail_timeout=0;
+  server unix:<%= application_socket %> fail_timeout=0 backup;
 }
 
 # Canonical www. redirect


### PR DESCRIPTION
This PR changes the TC vhost nginx config to try proxying the request to a TCP socket, before falling back to using a UNIX socket.

We want to run goreplay on TC so that we can test Rails 5 performance with some real-world traffic. To do this, we need TC to be listening on a TCP socket so we can attach the goreplay listener.

This nginx config should allow us to push a change to our TC unicorn config, that way we can switch over to TCP sockets with no downtime.

I should add that we can remove this configuration change once we're done with our goreplay testing.

See the [nginx manual](http://nginx.org/en/docs/http/ngx_http_upstream_module.html) for more details.