### PR TITLE
Install all npm packages on deploy

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -6,16 +6,6 @@ def on_standby?
   current_hostname == standby_hostname
 end
 
-dep 'npm development packages installed', :path do
-  met? {
-    output = raw_shell('npm ls --dev', :cd => path)
-    output.ok?
-  }
-  meet {
-    shell('npm install --only=dev', :cd => path)
-  }
-end
-
 dep 'npm packages installed', :path do
   met? {
     output = raw_shell('npm ls', :cd => path)
@@ -47,7 +37,7 @@ end
 
 dep 'webpack compile during deploy', :env, :path, :deploying, template: 'task' do
   path.default!('~/current')
-  requires 'npm development packages installed'.with(path)
+  requires 'npm packages installed'.with(path)
   run {
     shell('npm run webpack:prod', cd: path)
   }


### PR DESCRIPTION
This PR changes our npm install on deploy to include *all* packages.

We had an issue where npm packages specified in the `dependencies` object (in `package.json`) were being ignored.

I don't see the reason for forcing ourselves to specify all our packages in `devDependencies`. This is non-standard npm practice. Development dependencies are usually reserved for libraries which are required for development. All run-time dependencies should be specified in the `dependencies` object.

@jameshill @nickbrowne 