### PR TITLE
Ensure that npm is not run in production mode

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -8,12 +8,12 @@ end
 
 dep 'npm packages installed', :path do
   met? {
-    output = raw_shell('npm ls --production', :cd => path)
+    output = raw_shell('npm ls --production=false', :cd => path)
     # Older `npm` versions exit 0 on failure.
     output.ok? && output.stdout['UNMET DEPENDENCY'].nil?
   }
   meet {
-    shell('npm install --production', :cd => path)
+    shell('npm install --production=false', :cd => path)
   }
 end
 

--- a/deploy.rb
+++ b/deploy.rb
@@ -8,6 +8,8 @@ end
 
 dep 'npm packages installed', :path do
   met? {
+    # Prune extraneous packages.
+    shell('npm prune --production=false', :cd => path)
     output = raw_shell('npm ls --production=false', :cd => path)
     # Older `npm` versions exit 0 on failure.
     output.ok? && output.stdout['UNMET DEPENDENCY'].nil?


### PR DESCRIPTION
This PR fixes a mistake I made when [previously](https://github.com/conversation/babushka-deps/pull/49) trying to fix up our npm install process.

When we install packages we want to force npm to *not* run in production mode. This is because we also require development dependencies to be installed on our production servers.