### PR TITLE
update our standard ruby from 2.3 to 2.4

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -21,7 +21,7 @@ end
 dep 'ci prepared' do
   requires [
     'common:set.locale'.with(:locale_name => 'en_AU'),
-    'ruby.src'.with(:version => '2.3.5', :patchlevel => 'p376'),
+    'ruby.src'.with(:version => '2.4.2', :patchlevel => 'p198'),
   ]
 end
 

--- a/provision.rb
+++ b/provision.rb
@@ -198,7 +198,7 @@ dep 'host provisioned', :host, :host_name, :ref, :env, :app_name, :app_user, :do
       remote_babushka 'common:set.locale', :locale_name => 'en_AU'
 
       # Build ruby separately, because it changes the ruby binary for subsequent deps.
-      remote_babushka 'conversation:ruby.src', :version => '2.3.5', :patchlevel => 'p376'
+      remote_babushka 'conversation:ruby.src', :version => '2.4.2', :patchlevel => 'p198'
 
       # All the system-wide config for this app, like packages and user accounts.
       remote_babushka "conversation:system provisioned", :host_name => host_name, :env => env, :app_name => app_name, :app_user => app_user, :key => keys


### PR DESCRIPTION
This updates deps used for ci, staging and production.

None of this will be run on existing servers automatically. They've already been manually run on CI (to confirm our apps build green under ruby 2.4) and when we're happy with the change they'll need to be run manually on staging, standby and production.