### PR TITLE
Add Yarn to packages for provisioning

### DIFF
--- a/packages.rb
+++ b/packages.rb
@@ -44,6 +44,13 @@ dep 'nodejs.bin', :version do
   provides "node ~> #{version}"
 end
 
+dep 'yarn.npm', :version do
+  version.default!('1.2.1')
+  installs "yarn = #{version}"
+  requires 'nodejs.bin'
+  provides "yarn = #{version}"
+end
+
 dep 'coffeescript.bin', :version do
   version.default!('1.4.0')
   requires 'nodejs.bin'

--- a/tc.rb
+++ b/tc.rb
@@ -107,6 +107,7 @@ dep 'tc common packages' do
     'geoip.bin', # for geoip-c
     'aspell dictionary.lib',
     'coffeescript.bin', # for barista
+    'yarn.npm',
     'tidy.bin', # for upmark preprocessing in MarkdownController
     'imagemagick.bin', # for paperclip
     'pngquant.bin', # for reducing the size of PNGs


### PR DESCRIPTION
If we're moving to [yarn](https://yarnpkg.com/) we better make sure it's provisioned on the servers.

I've tested this on staging... 

- by editing the version to `1.2.0`
- running `babushka 'conversation:yarn.npm'` 
- confirming by `yarn --version` == `1.2.0`
- then bumping it back to `1.2.1`.
- confirming `yarn --version` == `1.2.1`

We can then settle on **`1.2.1`** across all dev & production environments.

Here's the yarn blog on determinism again. We read it back when it was first posted, but it's good to re-read and know what we're buying.

https://yarnpkg.com/blog/2017/05/31/determinism/

### Post-Requisites
- [ ] Provision on `production` & `standby`