### PR TITLE
Update yarn install command to include frozen-lockfile

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -33,7 +33,7 @@ dep 'yarn packages installed', :path do
     output.ok?
   }
   meet {
-    shell('yarn install', :cd => path)
+    shell('yarn install --frozen-lockfile', :cd => path)
   }
 end
 


### PR DESCRIPTION
Update to `yarn install --frozen-lockfile` 

Which will fail the install if an update needed. https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile

This prevents the scenario where someone might update and commit `package.json` but not commit the `yarn.lock` changes. This detects that `yarn.lock` and `package.json` are not in sync and fails.

This will be particularly handy in the switch to yarn, where someone might run **`npm install ...`** which would update the `package.json` but not touch `yarn.lock`.

### Prerequisites 
- [ ] #54 

### Post-requisites
- [ ] https://github.com/conversation/tc/pull/7266 (update deploy & CI scripts on TC)