### PR TITLE
Tweak yarn install on deploy

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -29,8 +29,12 @@ end
 
 dep 'yarn packages installed', :path do
   met? {
-    output = raw_shell('yarn check', :cd => path)
-    output.ok?
+    # We haven't found the right way to have yarn return non-zero when there's packages
+    # to install. As an interim measure, we're falling back to npm to check if
+    # work is required.
+    output = raw_shell('npm ls', :cd => path)
+    # Older `npm` versions exit 0 on failure.
+    output.ok? && output.stdout['UNMET DEPENDENCY'].nil?
   }
   meet {
     shell('yarn install --frozen-lockfile --production=false', :cd => path)

--- a/deploy.rb
+++ b/deploy.rb
@@ -33,7 +33,7 @@ dep 'yarn packages installed', :path do
     output.ok?
   }
   meet {
-    shell('yarn install --frozen-lockfile', :cd => path)
+    shell('yarn install --frozen-lockfile --production=false', :cd => path)
   }
 end
 


### PR DESCRIPTION
We ran into some issues when deploying analytics with yarn. These two changes seem to help (check the commit messages for more detail):

1. install devDependencies during deploys
2. use npm to decide if a yarn install is required on deploy 