### PR TITLE
stop hard coding the number of workers and threads for unicorn and puma

### DIFF
--- a/analytics.rb
+++ b/analytics.rb
@@ -26,8 +26,7 @@ dep 'analytics app', :env, :host, :domain, :app_user, :app_root, :key do
       :listen_host => host,
       :domain => domain,
       :username => app_user,
-      :path => app_root,
-      :threads => 8
+      :path => app_root
     )
   ]
 end

--- a/counter.rb
+++ b/counter.rb
@@ -31,8 +31,7 @@ dep 'counter app', :env, :host, :domain, :app_user, :app_root, :key do
       :listen_host => host,
       :domain => domain,
       :username => app_user,
-      :path => app_root,
-      :threads => 8
+      :path => app_root
     )
   ]
 end

--- a/dw.rb
+++ b/dw.rb
@@ -24,8 +24,7 @@ dep 'dw app', :env, :host, :domain, :app_user, :app_root, :key do
       :enable_https => 'no',
       :domain => domain,
       :username => app_user,
-      :path => app_root,
-      :threads => 6
+      :path => app_root
     )
   ]
 end

--- a/puma.rb
+++ b/puma.rb
@@ -1,14 +1,11 @@
-dep 'puma.systemd', :env, :path, :username, :threads, :workers do
-  threads.default!('4')
-  workers.default!('1')
-
+dep 'puma.systemd', :env, :path, :username do
   description "Puma HTTP server"
   respawn 'yes'
   pid_file (path / 'tmp/pids/puma.pid').abs
 
   puma_path = (path / 'bin/puma').abs
   socket_path = (path / "tmp/sockets/puma.socket").abs
-  command "#{puma_path} -b 'unix://#{socket_path}' -t #{threads} -w #{workers}"
+  command "#{puma_path} -b 'unix://#{socket_path}'"
   reload_command "/bin/kill -s USR1 $MAINPID" # reload workers
 
   setuid username

--- a/rack.rb
+++ b/rack.rb
@@ -1,4 +1,4 @@
-dep 'rails app', :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port, :threads, :workers do
+dep 'rails app', :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port do
   def has_webpack_config?
     (path / "webpack.config.js").exists?
   end
@@ -7,21 +7,21 @@ dep 'rails app', :app_name, :env, :domain, :username, :path, :listen_host, :list
     requires [
       'rack app'.with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
       'webpack compile during deploy'.with(env: env),
-      'config ruby app server'.with(app_name, path, env, username, threads, workers)
+      'config ruby app server'.with(app_name, path, env, username)
     ]
   else
     requires [
       'rack app'.with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
       'common:assets precompiled'.with(env: env, path: path),
-      'config ruby app server'.with(app_name, path, env, username, threads, workers)
+      'config ruby app server'.with(app_name, path, env, username)
     ]
   end
 end
 
-dep 'sinatra app', :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port, :threads, :workers do
+dep 'sinatra app', :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port do
   requires [
     'rack app'.with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
-    'config ruby app server'.with(app_name, path, env, username, threads, workers)
+    'config ruby app server'.with(app_name, path, env, username)
   ]
 end
 
@@ -39,7 +39,7 @@ dep 'rack app', :app_name, :env, :domain, :username, :path, :listen_host, :liste
   ]
 end
 
-dep 'config ruby app server', :app_name, :path, :env, :username, :threads, :workers do
+dep 'config ruby app server', :app_name, :path, :env, :username do
   def has_unicorn_config?
     (path / "config/unicorn.rb").exists?
   end
@@ -50,12 +50,12 @@ dep 'config ruby app server', :app_name, :path, :env, :username, :threads, :work
 
   if has_unicorn_config?
     requires [
-      'unicorn.systemd'.with(env, path, username, threads, workers),
+      'unicorn.systemd'.with(env, path, username),
       'log unicorn socket'.with(app_name, path, username)
     ]
   elsif has_puma_config?
     requires [
-      'puma.systemd'.with(env, path, username, threads, workers),
+      'puma.systemd'.with(env, path, username),
       'log puma socket'.with(app_name, path, username)
     ]
   end

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -1,6 +1,4 @@
-dep 'unicorn.systemd', :env, :path, :username, :threads, :workers do
-  threads.default!('4')
-  workers.default!('1')
+dep 'unicorn.systemd', :env, :path, :username do
 
   description "Unicorn HTTP server"
   respawn 'yes'
@@ -12,7 +10,7 @@ dep 'unicorn.systemd', :env, :path, :username, :threads, :workers do
 
   setuid username
   chdir path.p.abs
-  environment "APP_ENV=#{env}", "RACK_ENV=#{env}", "RAILS_ENV=#{env}", "UNICORN_THREADS=#{threads}", "UNICORN_WORKERS=#{workers}"
+  environment "APP_ENV=#{env}", "RACK_ENV=#{env}", "RAILS_ENV=#{env}"
 end
 
 dep 'log unicorn socket', :app_name, :path, :user  do


### PR DESCRIPTION
We'd like the option to control these values in configuration that lives inside each app repo.

In pumas case, we normally do a phased restart (USR1) during a deploy. It's worth noting that this style of restart *doesn't* pick up changes in the configuration file, so deploys with change to the puma config will need to do a regular restart (USR2)