### PR TITLE
Ensure sharejs logs are rotated

### DIFF
--- a/sharejs.rb
+++ b/sharejs.rb
@@ -56,5 +56,6 @@ dep 'sharejs setup', :username, :app_root, :db_name do
   requires [
     'schema loaded'.with(:username => username, :root => app_root, :db_name => db_name),
     'npm packages installed'.with('~/current'),
+    'rack.logrotate'.with(username),
   ]
 end


### PR DESCRIPTION
This PR adds the `rack.logrotate` dep to the sharejs app. Even though sharejs is a node app, the `rack.logrotate` dep only cares that the files are in the `log` directory.