### PR TITLE
Ensure firefox version 56 when provisioning ci

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -106,7 +106,13 @@ dep 'xvfb.bin' do
   provides 'Xvfb'
 end
 
-dep 'firefox.bin'
+dep 'firefox.bin', :version do
+  version.default!('56.0')
+
+  met? {
+    in_path? "firefox >= #{version}"
+  }
+end
 
 dep 'terraform', :version do
   version.default!('0.10.2')


### PR DESCRIPTION
It's available in apt, just need to poke it along. I need it to see if it works for https://github.com/conversation/tc/pull/7293

I think I did it properly, seems to work:
```
root@tank2:~/.babushka/sources/conversation# babushka 'conversation:firefox.bin'
conversation:firefox.bin {
  'firefox' runs from /usr/bin.
  firefox is 53.0.3, which isn't >= 56.0.
  apt {
    package manager {
      'apt-get' runs from /usr/bin.
    } ✓ package manager
    apt source {
    } ✓ apt source
    apt source {
    } ✓ apt source
  } ✓ apt
  meet {
    The apt package lists are 5 days old. Updating... done.
    Installing firefox via apt... done.
  }
  'firefox' runs from /usr/bin.
  ✓ firefox is >= 56.0.
} ✓ conversation:firefox.bin
```
