### PR TITLE
Require Spanish dictionaries for aspell

### DIFF
--- a/packages.rb
+++ b/packages.rb
@@ -7,7 +7,7 @@ dep 'aspell.bin'
 dep 'aspell dictionary.lib' do
   requires 'aspell.bin'
   installs {
-    on :linux, 'aspell-en', 'aspell-fr', 'aspell-id', 'libaspell-dev'
+    on :linux, 'aspell-en', 'aspell-fr', 'aspell-id', 'aspell-es', 'libaspell-dev'
     otherwise []
   }
 end


### PR DESCRIPTION
We are preparing to [add Spanish support](https://github.com/conversation/tc/pull/7336) for our spell checker, which relies on this aspell dictionary.
I think this needs to be added on the thanks, but I'm not sure how to do that?