### PR TITLE
Add a script that logs key puma metrics to a local statsd server

### DIFF
--- a/puma.rb
+++ b/puma.rb
@@ -27,3 +27,17 @@ dep 'puma-socket-statsd-logger.systemd', :app_name, :path, :user do
   setuid user
   chdir path.p.abs
 end
+
+dep 'log puma workers', :app_name, :path, :user  do
+  requires [
+    "script installed".with('puma-statsd-logger'),
+    "puma-statsd-logger.systemd".with(app_name, path, user)
+  ]
+end
+
+dep 'puma-statsd-logger.systemd', :app_name, :path, :user do
+  respawn 'yes'
+  command "/usr/local/bin/puma-statsd-logger #{path} #{app_name}.puma"
+  setuid user
+  chdir path.p.abs
+end

--- a/rack.rb
+++ b/rack.rb
@@ -56,7 +56,8 @@ dep 'config ruby app server', :app_name, :path, :env, :username do
   elsif has_puma_config?
     requires [
       'puma.systemd'.with(env, path, username),
-      'log puma socket'.with(app_name, path, username)
+      'log puma socket'.with(app_name, path, username),
+      'log puma workers'.with(app_name, path, username)
     ]
   end
 end

--- a/scripts/puma-statsd-logger
+++ b/scripts/puma-statsd-logger
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+
+# Polls puma for key stats every second and sends them to statsd, where they
+# can be graphed and monitored.
+#
+# The raw stats are retrieved by running `pumactl stats`. They're in JSON format,
+# so we extract the numbers we care about and use UDP to talk to statsd.
+#
+# Props to Tim Lucas and Sam Cochran for the basic structure:
+#
+#     https://gist.github.com/toolmantim/0e76d0377bb23974b06f
+#     https://github.com/sj26/puma-plugin-systemd
+#
+# We have a similar script for monitoring the unix socket between nginx and puma:
+#
+#     https://github.com/conversation/babushka-deps/blob/master/scripts/socket-statsd-logger
+# 
+require 'json'
+require 'socket'
+
+USAGE = "puma-statsd-logger <puma-app-path> <metric name>"
+METRIC_NAME_REGEXP = /\A[a-z][a-z\.]+[a-z]\Z/
+
+puma_app_path, metric_name = *ARGV
+
+if puma_app_path.nil? || metric_name.nil? || !metric_name.match(METRIC_NAME_REGEXP) || !File.directory?(puma_app_path)
+  $stderr.puts USAGE
+  exit(1)
+end
+
+# Take puma's stats and safely extract the values we care about
+class PumaStats
+  def initialize(stats)
+    @stats = stats
+  end
+
+  def clustered?
+    @stats.has_key? "workers"
+  end
+
+  def workers
+    @stats.fetch("workers", 1)
+  end
+
+  def booted_workers
+    @stats.fetch("booted_workers", 1)
+  end
+
+  def running
+    if clustered?
+      @stats["worker_status"].map { |s| s["last_status"].fetch("running", 0) }.inject(0, &:+)
+    else
+      @stats.fetch("running", 0)
+    end
+  end
+
+  def backlog
+    if clustered?
+      @stats["worker_status"].map { |s| s["last_status"].fetch("backlog", 0) }.inject(0, &:+)
+    else
+      @stats.fetch("backlog", 0)
+    end
+  end
+
+end
+
+loop do
+  data = `cd #{puma_app_path} && ./bin/pumactl stats`.strip.split("\n").last
+  stats = PumaStats.new(JSON.parse(data))
+  UDPSocket.new.send("#{metric_name}.workers:#{stats.workers}|g", 0, '127.0.0.1', 8125)
+  UDPSocket.new.send("#{metric_name}.booted_workers:#{stats.booted_workers}|g", 0, '127.0.0.1', 8125)
+  UDPSocket.new.send("#{metric_name}.running:#{stats.running}|g", 0, '127.0.0.1', 8125)
+  UDPSocket.new.send("#{metric_name}.backlog:#{stats.backlog}|g", 0, '127.0.0.1', 8125)
+
+  sleep(1)
+end


### PR DESCRIPTION
Traditionally we've deployed our apps with unicorn, and the key thing to monitor when watching for capacity issues is the socket between nginx and unicorn. If that backs up, users experience request queuing and we're at risk of serving 502s (fail whale).

For puma, we already have monitoring on the socket between nginx and puma - but that's less interesting. Puma doesn't queue requests on that socket, so it almost always looks empty.

puma has a master process and 1 or more worker processes, and requests appear to be queued inside the master process. So, to monitor the number of active and queued requests we need to ask the master process for some stats.

This script will do so every second, and send the key stats to a local statsd server. From their, our monitoring pipeline will send the data to librato where we can graph it on a dashboard.

I've incubated this script in the [analytics codebase](https://github.com/conversation/tc-analytics/pull/576), so I'm pretty confident it works well. This change just bakes it into our provisioning so it's run by systemd and automatically used for all our puma apps.

Props to Tim Lucas and Sam Cochran for the basic structure:

    https://gist.github.com/toolmantim/0e76d0377bb23974b06f
    https://github.com/sj26/puma-plugin-systemd