### PR TITLE
stop giving the DW user access to the TC database

### DIFF
--- a/tc.rb
+++ b/tc.rb
@@ -43,13 +43,6 @@ dep 'tc app', :env, :host, :domain, :app_user, :app_root, :key do
       :data_required => 'yes'
     ),
 
-    # The data warehouse importer needs read access to the tc DB.
-    'db access'.with(
-      :db_name => db_name,
-      :username => 'dw.theconversation.edu.au',
-      :check_table => 'content'
-    ),
-
     'postgres replication monitoring'.with(:test_user => app_user),
 
     'rails app'.with(


### PR DESCRIPTION
The DW used to connect to the TC database directly to fetch the data it wanted, but now all data is shared via the eventlog.

There were two related deps that were no longer used, so I removed them too.