### PR TITLE
Increase nginx request size limit.

### DIFF
--- a/nginx/counter_vhost.common.erb
+++ b/nginx/counter_vhost.common.erb
@@ -23,7 +23,6 @@ location @app {
 
   proxy_buffer_size    64k;
   proxy_buffers        32 16k;
-  client_max_body_size 128m;
 
   proxy_set_header     Host              $host;
   proxy_set_header     Client-Ip         $tc_client_ip;

--- a/nginx/nginx.conf.erb
+++ b/nginx/nginx.conf.erb
@@ -11,7 +11,7 @@ http {
   tcp_nopush on;
   tcp_nodelay off;
   keepalive_timeout 30;
-  client_max_body_size 16m;
+  client_max_body_size 32m;
   server_names_hash_max_size 8192;
 
   include /etc/nginx/mime.types;

--- a/nginx/standard_vhost.conf.erb
+++ b/nginx/standard_vhost.conf.erb
@@ -60,7 +60,6 @@ server {
 
     proxy_buffer_size    64k;
     proxy_buffers        32 16k;
-    client_max_body_size 128m;
 
     proxy_set_header     Host              $host;
     proxy_set_header     Client-Ip         $tc_client_ip;

--- a/nginx/tc_vhost.common.erb
+++ b/nginx/tc_vhost.common.erb
@@ -52,7 +52,6 @@ location @app {
 
   proxy_buffer_size    64k;
   proxy_buffers        32 16k;
-  client_max_body_size 128m;
 
   proxy_set_header     Host              $host;
   proxy_set_header     Client-Ip         $tc_client_ip;


### PR DESCRIPTION
Currently we're setting the maximum request size limit for nginx in many places, but the two of particular note are the overall limit of 16MB, and the tc-specific limit of 128MB.

From what @yob and I have found, it seems the overall limit is [the absolute maximum](https://stackoverflow.com/questions/2056124/nginx-client-max-body-size-has-no-effect#comment69143227_9329327) - apps/locations within can have lower limits, but not higher. So, there's no point setting a tc-specific limit. Also, we've had editors complain that images larger than 16MB can't be uploaded - this PR increases the overall limit to 32MB, which will likely be enough for the time being.

It'd be nice to have some client-side validation on the file size to provide more helpful errors around this, but that's not an issue for this repo :)