### PR TITLE
Remove listen_host and listen_port parameters

### DIFF
--- a/analytics.rb
+++ b/analytics.rb
@@ -24,7 +24,6 @@ dep "analytics app", :env, :host, :domain, :app_user, :app_root, :key do
     "rails app".with(
       app_name: "analytics",
       env: env,
-      listen_host: host,
       domain: domain,
       username: app_user,
       path: app_root

--- a/counter.rb
+++ b/counter.rb
@@ -25,7 +25,6 @@ dep "counter app", :env, :host, :domain, :app_user, :app_root, :key do
     "sinatra app".with(
       app_name: "counter",
       env: env,
-      listen_host: host,
       domain: domain,
       username: app_user,
       path: app_root

--- a/donations.rb
+++ b/donations.rb
@@ -23,7 +23,6 @@ dep "donations app", :env, :host, :domain, :app_user, :app_root, :key do
     "rails app".with(
       app_name: "donate",
       env: env,
-      listen_host: host,
       domain: domain,
       username: app_user,
       path: app_root

--- a/dw.rb
+++ b/dw.rb
@@ -20,7 +20,6 @@ dep "dw app", :env, :host, :domain, :app_user, :app_root, :key do
     "sinatra app".with(
       app_name: "dw",
       env: env,
-      listen_host: host,
       enable_https: "no",
       domain: domain,
       username: app_user,

--- a/jobs.rb
+++ b/jobs.rb
@@ -26,7 +26,6 @@ dep "jobs app", :env, :host, :domain, :app_user, :app_root, :key do
     "rails app".with(
       app_name: "jobs",
       env: env,
-      listen_host: host,
       domain: domain,
       username: app_user,
       path: app_root

--- a/nginx.rb
+++ b/nginx.rb
@@ -36,8 +36,8 @@ meta :nginx do
   end
 end
 
-dep "vhost enabled.nginx", :app_name, :env, :domain, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port do
-  requires "vhost configured.nginx".with(app_name, env, domain, path, listen_host, listen_port, enable_https, proxy_host, proxy_port)
+dep "vhost enabled.nginx", :app_name, :env, :domain, :path, :enable_https, :proxy_host, :proxy_port do
+  requires "vhost configured.nginx".with(app_name, env, domain, path, enable_https, proxy_host, proxy_port)
   met? { vhost_link.exists? }
   meet do
     sudo "ln -sf '#{vhost_conf}' '#{vhost_link}'"
@@ -45,10 +45,8 @@ dep "vhost enabled.nginx", :app_name, :env, :domain, :path, :listen_host, :liste
   after { reload_nginx }
 end
 
-dep "vhost configured.nginx", :app_name, :env, :domain, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port do
+dep "vhost configured.nginx", :app_name, :env, :domain, :path, :enable_https, :proxy_host, :proxy_port do
   env.default!("production")
-  listen_host.default!("[::]")
-  listen_port.default!("80")
   enable_https.default!("yes")
   proxy_host.default("localhost")
   proxy_port.default("8000")

--- a/nginx/counter_vhost.conf.erb
+++ b/nginx/counter_vhost.conf.erb
@@ -7,8 +7,7 @@ upstream <%= upstream_name %> {
 server {
   server_name <%= domain %>;
 
-  listen <%= listen_port %>;
-
+  listen 80;
   listen 443 ssl;
 
   ssl_certificate      /etc/ssl/certs/<%= domain %>.crt;

--- a/nginx/standard_vhost.conf.erb
+++ b/nginx/standard_vhost.conf.erb
@@ -6,7 +6,7 @@ upstream <%= upstream_name %> {
 
 # Canonical www. redirect
 server {
-  listen <%= listen_port %>;
+  listen 80;
   server_name www.<%= domain %>;
   return 301 http://<%= domain %>$request_uri;
 }
@@ -15,7 +15,7 @@ server {
   charset utf-8;
   server_name <%= domain %>;
 
-  listen <%= listen_port %>;
+  listen 80;
 
 <% if enable_https[/^y/] %>
   listen 443 ssl;

--- a/nginx/tc_vhost.conf.erb
+++ b/nginx/tc_vhost.conf.erb
@@ -7,14 +7,14 @@ upstream <%= upstream_name %> {
 
 # Canonical www. redirect
 server {
-  listen <%= listen_port %>;
+  listen 80;
   server_name www.<%= domain %>;
   return 301 http://<%= domain %>$request_uri;
 }
 
 # Canonical http:// vhost
 server {
-  listen <%= listen_port %>;
+  listen 80;
   server_name <%= domain %>;
 
   include /etc/nginx/sites-available/<%= domain %>.common;

--- a/rack.rb
+++ b/rack.rb
@@ -1,31 +1,31 @@
-dep "rails app", :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port do
+dep "rails app", :app_name, :env, :domain, :username, :path, :enable_https, :proxy_host, :proxy_port do
   def has_webpack_config?
     (path / "webpack.config.js").exists?
   end
 
   if has_webpack_config?
     requires [
-      "rack app".with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
+      "rack app".with(app_name, env, domain, username, path, enable_https, proxy_host, proxy_port),
       "webpack compile during deploy".with(env: env),
       "config ruby app server".with(app_name, path, env, username)
     ]
   else
     requires [
-      "rack app".with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
+      "rack app".with(app_name, env, domain, username, path, enable_https, proxy_host, proxy_port),
       "common:assets precompiled".with(env: env, path: path),
       "config ruby app server".with(app_name, path, env, username)
     ]
   end
 end
 
-dep "sinatra app", :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port do
+dep "sinatra app", :app_name, :env, :domain, :username, :path, :enable_https, :proxy_host, :proxy_port do
   requires [
-    "rack app".with(app_name, env, domain, username, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
+    "rack app".with(app_name, env, domain, username, path, enable_https, proxy_host, proxy_port),
     "config ruby app server".with(app_name, path, env, username)
   ]
 end
 
-dep "rack app", :app_name, :env, :domain, :username, :path, :listen_host, :listen_port, :enable_https, :proxy_host, :proxy_port do
+dep "rack app", :app_name, :env, :domain, :username, :path, :enable_https, :proxy_host, :proxy_port do
   username.default!(domain)
   path.default("~/current")
   env.default(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "production")
@@ -33,7 +33,7 @@ dep "rack app", :app_name, :env, :domain, :username, :path, :listen_host, :liste
   requires [
     "user exists".with(username, "/srv/http"),
     "app bundled".with(path, env),
-    "vhost enabled.nginx".with(app_name, env, domain, path, listen_host, listen_port, enable_https, proxy_host, proxy_port),
+    "vhost enabled.nginx".with(app_name, env, domain, path, enable_https, proxy_host, proxy_port),
     "rack.logrotate".with(username),
     "running.nginx"
   ]

--- a/tc.rb
+++ b/tc.rb
@@ -42,7 +42,6 @@ dep "tc app", :env, :host, :domain, :app_user, :app_root, :key do
     "rails app".with(
       app_name: "tc",
       env: env,
-      listen_host: host,
       domain: domain,
       username: app_user,
       path: app_root,


### PR DESCRIPTION
I removed the `listen_host` and `listen_port` parameters because I don't think they are worth keeping. Maybe they used to be used for something, but now I think they are just complicating our deps.

The `listen_host` parameter wasn't even being used anywhere. It was just getting passed around for nothing.