### PR TITLE
Allow nginx to proxy to sharejs on ports 9000 and 9001

### DIFF
--- a/nginx.rb
+++ b/nginx.rb
@@ -26,8 +26,8 @@ meta :nginx do
   end
 end
 
-dep "vhost enabled.nginx", :app_name, :env, :domain, :path, :enable_https, :proxy_host, :proxy_port do
-  requires "vhost configured.nginx".with(app_name, env, domain, path, enable_https, proxy_host, proxy_port)
+dep "vhost enabled.nginx", :app_name, :env, :domain, :path, :enable_https do
+  requires "vhost configured.nginx".with(app_name, env, domain, path, enable_https)
 
   met? { vhost_link.exists? }
 
@@ -38,11 +38,9 @@ dep "vhost enabled.nginx", :app_name, :env, :domain, :path, :enable_https, :prox
   after { Util.reload_service('nginx') }
 end
 
-dep "vhost configured.nginx", :app_name, :env, :domain, :path, :enable_https, :proxy_host, :proxy_port do
+dep "vhost configured.nginx", :app_name, :env, :domain, :path, :enable_https do
   env.default!("production")
   enable_https.default!("yes")
-  proxy_host.default("localhost")
-  proxy_port.default("8000")
 
   def application_socket
     if has_unicorn_config?

--- a/nginx/tc_vhost.common.erb
+++ b/nginx/tc_vhost.common.erb
@@ -17,7 +17,7 @@ location ~ ^/assets/ {
 location /sharejs/ {
   # auth_basic off;
 
-  proxy_pass            http://<%= proxy_host %>:<%= proxy_port %>/;
+  proxy_pass            http://sharejs/;
   proxy_redirect        off;
 
   proxy_set_header      Host            $host;

--- a/nginx/tc_vhost.conf.erb
+++ b/nginx/tc_vhost.conf.erb
@@ -5,6 +5,11 @@ upstream <%= upstream_name %> {
   server unix:<%= application_socket %> fail_timeout=0;
 }
 
+upstream sharejs {
+  server 127.0.0.1:9000 backup;
+  server 127.0.0.1:9001;
+}
+
 # Canonical www. redirect
 server {
   listen 80;

--- a/proxied.rb
+++ b/proxied.rb
@@ -1,9 +1,0 @@
-dep "proxied app", :env, :app_name, :domain, :port do
-  requires "#{app_name}".with(env)
-  requires "vhost enabled.nginx".with(
-    domain: domain,
-    type: "proxy",
-    proxy_host: "localhost",
-    proxy_port: port
-  )
-end

--- a/rack.rb
+++ b/rack.rb
@@ -1,31 +1,31 @@
-dep "rails app", :app_name, :env, :domain, :username, :path, :enable_https, :proxy_host, :proxy_port do
+dep "rails app", :app_name, :env, :domain, :username, :path, :enable_https do
   def has_webpack_config?
     (path / "webpack.config.js").exists?
   end
 
   if has_webpack_config?
     requires [
-      "rack app".with(app_name, env, domain, username, path, enable_https, proxy_host, proxy_port),
+      "rack app".with(app_name, env, domain, username, path, enable_https),
       "webpack compile during deploy".with(env: env),
       "config ruby app server".with(app_name, path, env, username)
     ]
   else
     requires [
-      "rack app".with(app_name, env, domain, username, path, enable_https, proxy_host, proxy_port),
+      "rack app".with(app_name, env, domain, username, path, enable_https),
       "common:assets precompiled".with(env: env, path: path),
       "config ruby app server".with(app_name, path, env, username)
     ]
   end
 end
 
-dep "sinatra app", :app_name, :env, :domain, :username, :path, :enable_https, :proxy_host, :proxy_port do
+dep "sinatra app", :app_name, :env, :domain, :username, :path, :enable_https do
   requires [
-    "rack app".with(app_name, env, domain, username, path, enable_https, proxy_host, proxy_port),
+    "rack app".with(app_name, env, domain, username, path, enable_https),
     "config ruby app server".with(app_name, path, env, username)
   ]
 end
 
-dep "rack app", :app_name, :env, :domain, :username, :path, :enable_https, :proxy_host, :proxy_port do
+dep "rack app", :app_name, :env, :domain, :username, :path, :enable_https do
   username.default!(domain)
   path.default("~/current")
   env.default(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "production")
@@ -33,7 +33,7 @@ dep "rack app", :app_name, :env, :domain, :username, :path, :enable_https, :prox
   requires [
     "user exists".with(username, "/srv/http"),
     "app bundled".with(path, env),
-    "vhost enabled.nginx".with(app_name, env, domain, path, enable_https, proxy_host, proxy_port),
+    "vhost enabled.nginx".with(app_name, env, domain, path, enable_https),
     "rack.logrotate".with(username),
     "running.nginx"
   ]

--- a/tc.rb
+++ b/tc.rb
@@ -44,9 +44,7 @@ dep "tc app", :env, :host, :domain, :app_user, :app_root, :key do
       env: env,
       domain: domain,
       username: app_user,
-      path: app_root,
-      proxy_host: "127.0.0.1",
-      proxy_port: 9000
+      path: app_root
     )
   ]
 end


### PR DESCRIPTION
This is part of our strategy to deploy a dockerised sharejs app.

The idea is that if we configure nginx to proxy sharejs request to ports `9000` *and* `9001`, then we can move the bare-metal app to port 9001 (with minimal downtime). Once the bare-metal app is running on port `9001`, then we can deploy the dockerised app on port `9000`.

Port `9000` is marked as `backup` in the [nginx config](http://nginx.org/en/docs/http/ngx_http_upstream_module.html), so nginx will only proxy requests to it if there isn't anything listening on `9001`. This means that we can start routing requests to the dockerised app simply by switching off the bare-metal app. If things go wrong, then we can just turn the bare-metal app back on and nginx will automatically start proxying to it again.