### PR TITLE
Change sharejs to listen on port 9001

### DIFF
--- a/sharejs.rb
+++ b/sharejs.rb
@@ -40,7 +40,7 @@ dep "sharejs.systemd", :username, :env, :app_root, :db_name do
 
   description "ShareJS server"
   command "/usr/bin/npm start"
-  environment "NODE_ENV=#{env}"
+  environment "NODE_ENV=#{env}", "PORT=9001"
   setuid username
   chdir "/srv/http/#{username}/current"
   respawn "yes"


### PR DESCRIPTION
Depends on #68. This is part of our strategy to deploy a dockerised sharejs app.

Now that nginx will proxy sharejs requests to ports `9000` *and* `9001`, let's move sharejs to listen on port `9001`. This will make room for the dockerised app.