### PR TITLE
Upgrade Firefox to its v58

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -113,7 +113,7 @@ dep "xvfb.bin" do
 end
 
 dep "firefox.bin", :version do
-  version.default!("56.0")
+  version.default!("58.0")
 
   met? do
     in_path? "firefox >= #{version}"


### PR DESCRIPTION
Based on PR https://github.com/conversation/babushka-deps/pull/59, this PR aims to provision Firefox v58 instead of v56.