### PR TITLE
Add dep to provision data warehouse

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -32,7 +32,7 @@ end
 
 dep "schema loaded", :username, :root, :schema_path, :db_name do
   root.default!(".")
-  schema_path.default!("db/schema.sql")
+  schema_path.default!(root / "db/schema.sql")
   requires "existing db".with(username, db_name)
 
   met? do
@@ -44,7 +44,7 @@ dep "schema loaded", :username, :root, :schema_path, :db_name do
   end
 
   meet do
-    log_shell "Applying #{schema_path} to #{db_name}", "psql #{db_name} -f -", input: (root / schema_path).p.read!
+    log_shell "Applying #{schema_path} to #{db_name}", "psql #{db_name} -f -", input: schema_path.p.read!
   end
 end
 

--- a/docker.rb
+++ b/docker.rb
@@ -96,3 +96,23 @@ dep "docker credentials" do
     shell "chmod a+x /usr/local/bin/docker-credential-ecr-login"
   end
 end
+
+dep 'docker swarm initialised' do
+  met? do
+    shell('docker info').val_for('Swarm') == 'active'
+  end
+
+  meet do
+    shell 'docker swarm init'
+  end
+end
+
+dep 'docker secret', :key, :value do
+  met? do
+    shell? "docker secret inspect #{key}"
+  end
+
+  meet do
+    shell "echo '#{value}' | docker secret create #{key} -"
+  end
+end

--- a/dw.rb
+++ b/dw.rb
@@ -1,49 +1,127 @@
-dep "dw system", :app_user, :key, :env
+dep(
+  'provision dw',
+  :aws_secret_access_key,
+  :bugsnag_api_key,
+  :database_password,
+  :domain,
+  :env,
+  :force,
+  :host,
+  :keys,
+  template: 'remote'
+) do
+  if env == 'production'
+    domain.default!('dw.theconversation.com')
+  else
+    domain.default!('dw.tc-dev.net')
+  end
 
-dep "dw env vars set", :domain
+  force.default!('no')
+  keys.default!((dependency.load_path.parent / "config/authorized_keys").read)
 
-dep "dw app", :env, :host, :domain, :app_user, :app_root, :key do
+  requires_when_unmet "public key in place".with(host, keys)
+  requires_when_unmet "babushka bootstrapped".with(host)
+  requires_when_unmet 'app certs installed'.with(host: host)
+
+  before do
+    shell "scp db/schema.sql root@#{host}:/tmp/"
+  end
+
+  met? do
+    curl = "curl -v -L --connect-timeout 5 --max-time 30 --resolve #{domain}:80:#{host} --resolve #{domain}:443:#{host}"
+    cmd = raw_shell("#{curl} http://#{domain}/health")
+
+    if !cmd.ok?
+      log "Couldn't connect to http://#{host}."
+      false
+    elsif force == 'yes'
+      log 'Forcing...'
+      false
+    else
+      log_ok "#{host} is up."
+
+      if cmd.stderr.val_for('Status') != '200 OK'
+        log_warn "#{domain} on #{host} reported a problem:\n#{cmd.stdout}"
+      else
+        log_ok "#{domain} on #{host} responded with 200 OK."
+      end
+
+      true
+    end
+  end
+
+  meet do
+    remote_babushka(
+      'conversation:dw app',
+      aws_secret_access_key: aws_secret_access_key,
+      bugsnag_api_key: bugsnag_api_key,
+      database_host: "db.#{env}.tc-dev.net",
+      database_name: 'dw',
+      database_password: database_password,
+      database_username: 'dw.theconversation.com',
+      domain: domain
+    )
+  end
+end
+
+dep(
+  'dw app',
+  :aws_secret_access_key,
+  :bugsnag_api_key,
+  :database_host,
+  :database_name,
+  :database_password,
+  :database_username,
+  :domain
+) do
+  def database_url
+    "postgres://#{database_username}:#{database_password}@#{database_host}:5432/#{database_name}"
+  end
+
   requires [
-    "migrated db".with(
-      username: app_user,
-      root: app_root,
-      env: env,
-      db_name: "tc_dw_#{env}",
-      deploying: "no"
+    'dw packages',
+
+    # Ensure root has the superuser role.
+    'postgres access'.with(
+      username: 'root',
+      flags: '--superuser'
     ),
 
-    "delayed job".with(
-      env: env,
-      user: app_user
+    'postgres access'.with(
+      username: database_username,
+      password: database_password
     ),
 
-    "sinatra app".with(
-      app_name: "dw",
-      env: env,
-      enable_https: "no",
+    'existing db'.with(
+      db_name: database_name,
+      username: database_username
+    ),
+
+    'schema loaded'.with(
+      db_name: database_name,
+      username: database_username,
+      schema_path: '/tmp/schema.sql'
+    ),
+
+    'docker swarm initialised',
+
+    'docker secret'.with(key: 'dw_aws_secret_access_key', value: aws_secret_access_key),
+    'docker secret'.with(key: 'dw_database_url', value: database_url),
+    'docker secret'.with(key: 'dw_bugsnag_api_key', value: bugsnag_api_key),
+
+    'proxy vhost enabled.nginx'.with(
+      app_name: 'dw',
       domain: domain,
-      username: app_user,
-      path: app_root
+      enable_https: 'no',
+      proxy_port: '9292'
     )
   ]
 end
 
-dep "dw packages" do
+dep 'dw packages' do
   requires [
-    "postgres",
-    "curl.lib",
-    "running.nginx",
-    "dw common packages"
-  ]
-end
-
-dep "dw dev" do
-  requires "dw common packages"
-end
-
-dep "dw common packages" do
-  requires [
-    "bundler.gem",
-    "postgres.bin"
+    'docker.bin',
+    'docker-compose',
+    'docker-gc'
   ]
 end

--- a/nginx/dw_vhost.conf.erb
+++ b/nginx/dw_vhost.conf.erb
@@ -1,1 +1,1 @@
-standard_vhost.conf.erb
+proxy_vhost.conf.erb

--- a/nginx/proxy_vhost.conf.erb
+++ b/nginx/proxy_vhost.conf.erb
@@ -1,0 +1,29 @@
+server {
+  charset utf-8;
+  server_name <%= domain %>;
+  listen 80;
+<% if enable_https[/^y/] %>
+  listen 443 ssl;
+
+  ssl_certificate      /etc/ssl/certs/<%= domain %>.crt;
+  ssl_certificate_key  /etc/ssl/private/<%= domain %>.key;
+  ssl_session_timeout  5m;
+  ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers          ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:HIGH:!aNULL:!MD5:!kEDH;
+  ssl_prefer_server_ciphers on;
+<% end %>
+
+  location / {
+    proxy_pass           http://127.0.0.1:<%= proxy_port %>;
+    proxy_redirect       off;
+
+    proxy_buffer_size    64k;
+    proxy_buffers        32 16k;
+
+    proxy_set_header     Host              $host;
+    proxy_set_header     Client-Ip         $tc_client_ip;
+    proxy_set_header     X-Real-IP         $remote_addr;
+    proxy_set_header     X-Forwarded-Proto $tc_client_scheme;
+    proxy_set_header     X-Request-Start   "t=${msec}";
+  }
+}


### PR DESCRIPTION
This PR adds a dep to provision our data warehouse. We can later generalise this dep to provision our other dockerised apps.

It would be nice to role with Ansible for provisioning our dockerised apps, but I don't think that's realistic at this point. So...here's some more babs deps!

Babushka needs to be run from the DW app directory on your local machine:

    > babushka 'conversation:provision dw' env=staging host=staging-bhs.tc-dev.net force=yes

It will:

- Copy the SSL certs and keys to the appropriate directories.

  DW doesn't have any certs because it doesn't listen on 443, but if it did we would need to put the certs in `config/ssl/certs` and the keys in `config/ssl/private`. This matches the directory structure in Ubuntu and makes rsync possible.
- Copy the `schema.sql` file to the remote host to use when provisioning the database.
- Provision the postgres role and database.
- Configure the appropriate docker secrets.
- Configure the nginx proxy vhost.