### PR TITLE
Install chromedriver and Chromium on CI

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -48,6 +48,7 @@ dep "ci packages" do
     "ack-grep.bin",
     "silversearcher.bin",
     "chromedriver",
+    "chromium-browser.bin",
     "docker.bin",
     "docker-compose",
     "firefox.bin",
@@ -175,6 +176,14 @@ dep "chromedriver", :version do
     Babushka::Resource.extract chromedriver_uri do |_archive|
       shell "mv ./chromedriver /usr/local/bin"
     end
+  end
+end
+
+dep "chromium-browser.bin", :version do
+  version.default!("64")
+
+  met? do
+    in_path? "chromium-browser >= #{version}"
   end
 end
 

--- a/ci.rb
+++ b/ci.rb
@@ -47,6 +47,7 @@ dep "ci packages" do
   requires [
     "ack-grep.bin",
     "silversearcher.bin",
+    "chromedriver",
     "docker.bin",
     "docker-compose",
     "firefox.bin",
@@ -149,6 +150,30 @@ dep "geckodriver", :version do
     shell "wget #{geckodriver_uri} -O #{temp_archive}"
     Babushka::Asset.for(temp_archive).extract do |_archive|
       shell "mv ./geckodriver /usr/local/bin"
+    end
+  end
+end
+
+dep "chromedriver", :version do
+  version.default!("2.35")
+
+  def chromedriver_uri
+    if Babushka.host.linux?
+      "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_linux64.zip"
+    elsif Babushka.host.osx?
+      "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"
+    else
+      unmeetable! "Not sure where to download a chromedriver binary for #{Babushka.base.host}."
+    end
+  end
+
+  met? do
+    in_path? "chromedriver >= #{version}"
+  end
+
+  meet do
+    Babushka::Resource.extract chromedriver_uri do |_archive|
+      shell "mv ./chromedriver /usr/local/bin"
     end
   end
 end


### PR DESCRIPTION
Adding `chromedriver` and `chromium-browser` to CI recipes.