### PR TITLE
Change docker-gc grace period

### DIFF
--- a/docker/docker-gc.erb
+++ b/docker/docker-gc.erb
@@ -5,6 +5,7 @@ set -e
 docker run --rm \
 -e FORCE_IMAGE_REMOVAL=1 \
 -e MINIMUM_IMAGES_TO_SAVE=10 \
+-e GRACE_PERIOD_SECONDS=86400 \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /etc:/etc:ro \
 spotify/docker-gc


### PR DESCRIPTION
We are using [docker-gc](https://github.com/spotify/docker-gc) to clean up our docker images and containers on CI.

By default it won't delete containers or images less than one hour old, which means that docker builds can only use cached images for 1 hour. I bumped this up to 1 day (we could go even higher). More info: https://github.com/spotify/docker-gc#excluding-recently-exited-containers-and-images-from-garbage-collection