### PR TITLE
Enable basic auth for data warehouse

### DIFF
--- a/nginx/dw_vhost.conf.erb
+++ b/nginx/dw_vhost.conf.erb
@@ -1,1 +1,36 @@
-proxy_vhost.conf.erb
+server {
+  charset utf-8;
+  server_name <%= domain %>;
+  listen 80;
+<% if enable_https[/^y/] %>
+  listen 443 ssl;
+
+  ssl_certificate      /etc/ssl/certs/<%= domain %>.crt;
+  ssl_certificate_key  /etc/ssl/private/<%= domain %>.key;
+  ssl_session_timeout  5m;
+  ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers          ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:HIGH:!aNULL:!MD5:!kEDH;
+  ssl_prefer_server_ciphers on;
+<% end %>
+
+  location / {
+    satisfy any;
+    allow 127.0.0.1; # Allow local connections
+    allow 172.16.0.0/12; # Allow connections from docker
+    deny all;
+    auth_basic "Authentication Required";
+    auth_basic_user_file .htpasswd;
+
+    proxy_pass           http://127.0.0.1:<%= proxy_port %>;
+    proxy_redirect       off;
+
+    proxy_buffer_size    64k;
+    proxy_buffers        32 16k;
+
+    proxy_set_header     Host              $host;
+    proxy_set_header     Client-Ip         $tc_client_ip;
+    proxy_set_header     X-Real-IP         $remote_addr;
+    proxy_set_header     X-Forwarded-Proto $tc_client_scheme;
+    proxy_set_header     X-Request-Start   "t=${msec}";
+  }
+}


### PR DESCRIPTION
This will require manually creating a `.htpasswd` file with the credentials for our external apps and placing it in the `/etc/nginx` directory. I have already created this file with users `joel` and `diver`, the credentials are in 1password.

Connections from the localhost (`127.0.0.1`) and docker (`172.16.0.0/12`) are allowed without authentication. This means our existing apps won't require authentication.