### PR TITLE
Ensure npm@5.5.1 and Node 8 LTS

### DIFF
--- a/packages.rb
+++ b/packages.rb
@@ -29,6 +29,19 @@ dep "collectd.bin" do
   end
 end
 
+dep "npm.bin" do
+  met? do
+    npm_version = log_shell("checking for npm@5.5.1", "npm --version")
+    npm_version == "5.5.1"
+  end
+
+  meet do
+    log_shell("installing npm 5.5.1", "npm install --global npm@5.5.1")
+  end
+
+  requires "nodejs.bin"
+end
+
 dep "nodejs.bin", :version do
   version.default!("8")
   requires_when_unmet do

--- a/packages.rb
+++ b/packages.rb
@@ -30,10 +30,10 @@ dep "collectd.bin" do
 end
 
 dep "nodejs.bin", :version do
-  version.default!("6.10")
+  version.default!("8")
   requires_when_unmet do
     on :apt, "keyed apt source".with(
-      uri: "https://deb.nodesource.com/node_6.x",
+      uri: "https://deb.nodesource.com/node_8.x",
       release: "xenial",
       repo: "main",
       key_sig: "68576280",


### PR DESCRIPTION
I was hoping this was going to be as easy as bumping the Node version, but unfortunately [a bug was introduced in npm 5.6.0](https://github.com/npm/npm/issues/19393) which would break our deploy scripts that rely on `npm ls` behaving in a particular way.

Fortunately I was able to just add another dep which ensured we have a version of npm which does not suffer from that bug. I've tested it fairly extensively on staging, for example here's the `npm.bin` dep running, which bumps us up to Node 8, and ensures we have npm 5.5.1 installed:
```shell
> babushka "conversation:npm.bin"
conversation:npm.bin {
  conversation:nodejs.bin {
    'node ~> 8' is missing.
    apt {
      package manager {
        'apt-get' runs from /usr/bin.
      } ✓ package manager
      apt source {
      } ✓ apt source
      apt source {
      } ✓ apt source
    } ✓ apt
    keyed apt source {
      apt source {
      } ✓ apt source
    } ✓ keyed apt source
    meet {
      Installing nodejs via apt... done.
    }
    'node' runs from /usr/bin.
    ✓ node is 8.11.1, which is ~> 8.
  } ✓ conversation:nodejs.bin
  checking for npm@5.5.1... done.
  ✓ apt (cached)
  meet {
    installing npm 5.5.1... done.
  }
  checking for npm@5.5.1... done.
} ✓ conversation:npm.bin
```

And finally, here's the TC user running the our webpack compile after the upgrades:
```shell
> node -v
v8.11.1
> npm -v
5.5.1
> babushka "conversation:webpack compile during deploy"
conversation:webpack compile during deploy {
  conversation:npm development packages installed {
  } ✓ conversation:npm development packages installed
  meet {
  }
} ✓ conversation:webpack compile during deploy
> ls -lah public/assets | grep ".js$\|.css$"
-rw-rw-r--  1 theconversation.com theconversation.com  100 May  4 08:01 amp-d7d3fddf009e9f7c2825.js
-rw-rw-r--  1 theconversation.com theconversation.com 356K May  4 08:01 application-454230b3554abcba750c.js
-rw-rw-r--  1 theconversation.com theconversation.com 1.1M May  4 08:01 author-617688ba0e1d4fce6075.js
-rw-rw-r--  1 theconversation.com theconversation.com  101 May  4 08:01 core-b1e99b43b62c99d6439e.js
...SNIP
```