### PR TITLE
Add user interface worker to TC

### DIFF
--- a/tc.rb
+++ b/tc.rb
@@ -25,6 +25,12 @@ dep "tc app", :env, :host, :domain, :app_user, :app_root, :key do
       queue: "mailers"
     ),
 
+    "delayed job".with(
+      env: env,
+      user: app_user,
+      queue: "user_interface"
+    ),
+
     "db".with(
       env: env,
       username: app_user,


### PR DESCRIPTION
Adding an extra worker process to the `tc app` dependency, so the new `user_interface` `Delayed::Job` queue is processed in a separate worker.