### PR TITLE
Ensure job with our particular params is running

### DIFF
--- a/delayed_job.rb
+++ b/delayed_job.rb
@@ -20,7 +20,7 @@ dep "delayed_job.systemd", :env, :user, :queue do
   chdir "/srv/http/#{user}/current"
 
   met? do
-    shell?("ps ux | grep -v grep | grep 'rake jobs:work'")
+    shell?("ps u -u #{user} | grep -v grep | grep 'rake jobs:work #{vars.join(' ')}'")
   end
 end
 


### PR DESCRIPTION
Not just any old delayed job worker!

I'd originally planned to just use systemctl to check the status of the job, but we're actually already doing that in the systemd meta dep. It is somewhat important to check that the appropriate ruby process was successfully started by the service, so I've just fixed the check to look for the expected env vars.

This has been tested on staging and works as expected, I can start and stop any service in any order, re-run the deps and each of the workers starts appropriately.

This fixes the problem we're seeing on prod, where if you already have any kind of delayed job worker running, and try to run the `"delayed job"` dep to create a new one, it will silently fail because the `met?` block matches on any process that has `rake jobs:work` in it.