### PR TITLE
Set simpler defaults & allow mail images

### DIFF
--- a/nginx/tc_vhost.common.erb
+++ b/nginx/tc_vhost.common.erb
@@ -6,11 +6,14 @@ root <%= path / 'public' %>;
 # auth_basic_user_file .htpasswd;
 
 location ~ ^/assets/ {
+  auth_basic off;
+
   expires max;
   gzip_static on;
   add_header Cache-Control public;
   add_header Last-Modified "";
   add_header ETag "";
+
   break;
 }
 

--- a/nginx/tc_vhost.common.erb
+++ b/nginx/tc_vhost.common.erb
@@ -3,7 +3,7 @@ charset utf-8;
 root <%= path / 'public' %>;
 
 # auth_basic "Restricted";
-# auth_basic_user_file htpasswd;
+# auth_basic_user_file .htpasswd;
 
 location ~ ^/assets/ {
   expires max;
@@ -15,7 +15,7 @@ location ~ ^/assets/ {
 }
 
 location /sharejs/ {
-  # auth_basic off;
+  auth_basic off;
 
   proxy_pass            http://127.0.0.1:9000/;
   proxy_redirect        off;


### PR DESCRIPTION
Recently a provision overwrote nginx config on staging. The [dev docs](https://github.com/conversation/dev-docs/blob/master/provisioning.md#provisioning-staging) provide some post-provisioning configuration that needs to be done. We can reduce the changes needed by setting defaults that work for both staging and production environments.

Additionally, we address an issue where mailer images were not loading on staging. Basic auth currently blocks them, so we disable basic auth for assets.

See also:
- https://github.com/conversation/tc/pull/8190
- https://github.com/conversation/dev-docs/pull/67