### PR TITLE
Add deps to configure Datadog agent and dogstatsd

### DIFF
--- a/datadog.rb
+++ b/datadog.rb
@@ -1,0 +1,48 @@
+dep "datadog agent installed", :datadog_api_key do
+  requires [
+    "datadog-agent.bin",
+    "datadog api key installed".with(datadog_api_key: datadog_api_key)
+  ]
+
+  met? do
+    shell? "systemctl status datadog-agent"
+  end
+
+  meet do
+    log_shell "starting datadog-agent", "systemctl restart datadog-agent"
+  end
+end
+
+dep "datadog-agent.bin", :version do
+  version.default!("6.0")
+
+  requires [
+    "apt-transport-https.bin",
+    "datadog apt key installed",
+  ]
+
+  requires_when_unmet do
+    on :apt, "apt source".with(
+      uri: "https://apt.datadoghq.com/",
+      uri_matcher: "https://apt.datadoghq.com/",
+      release: "stable",
+      repo: "6",
+    )
+  end
+
+  installs do
+    via :apt, "datadog-agent"
+  end
+
+  provides "datadog-agent"
+end
+
+dep "datadog api key installed", :datadog_api_key do
+  met? { "/etc/datadog-agent/datadog.yaml".p.grep(/#{datadog_api_key}/) }
+  meet { sudo %Q(sed 's/api_key:.*/api_key: #{datadog_api_key}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml) }
+end
+
+dep "datadog apt key installed" do
+  met? { shell("apt-key list").split("\n").collapse(/^pub.*\//).val_for("382E94DE") }
+  meet { sudo("apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE") }
+end

--- a/provision.rb
+++ b/provision.rb
@@ -240,7 +240,7 @@ dep "apt configured" do
   ]
 end
 
-dep "system provisioned", :host_name, :env, :app_name, :app_user, :key, :mailgun_password do
+dep "system provisioned", :host_name, :env, :app_name, :app_user, :key, :mailgun_password, :datadog_api_key do
   requires [
     "localhost hosts entry",
     "hostname".with(host_name),
@@ -258,7 +258,8 @@ dep "system provisioned", :host_name, :env, :app_name, :app_user, :key, :mailgun
     "#{app_name} packages",
     "user setup".with(key: key),
     "#{app_name} system".with(app_user, key, env),
-    "user setup for provisioning".with(app_user, key)
+    "user setup for provisioning".with(app_user, key),
+    "datadog agent installed".with(datadog_api_key)
   ]
   setup do
     unmeetable! "This dep has to be run as root." unless shell("whoami") == "root"


### PR DESCRIPTION
I've been testing this on staging and it works just fine, after switching TC to report stats on port 8126 instead of 8125 everything flowed through to Datadog as expected.

The only part I'm not sure about is where an appropriate place for the `datadog agent installed` is in terms of provisioning. @nullobject any pro tips?