### PR TITLE
Add network connection state tracking to datadog agent config

### DIFF
--- a/datadog.rb
+++ b/datadog.rb
@@ -55,6 +55,14 @@ dep "datadog configured", :datadog_api_key, :datadog_postgres_password do
     "/etc/datadog-agent/conf.d/docker.d/conf.yaml".p
   end
 
+  def network_src
+    "datadog/network.yaml.erb".p
+  end
+
+  def network_dest
+    "/etc/datadog-agent/conf.d/network.d/conf.yaml".p
+  end
+
   def nginx_src
     "datadog/nginx.yaml.erb".p
   end
@@ -78,6 +86,7 @@ dep "datadog configured", :datadog_api_key, :datadog_postgres_password do
   met? do
     up_to_date?(datadog_src, datadog_dest) &&
     up_to_date?(docker_src, docker_dest) &&
+    up_to_date?(network_src, network_dest) &&
     up_to_date?(nginx_src, nginx_dest) &&
     up_to_date?(postgres_src, postgres_dest)
   end
@@ -85,6 +94,7 @@ dep "datadog configured", :datadog_api_key, :datadog_postgres_password do
   meet do
     render_erb datadog_src, to: datadog_dest, sudo: true
     render_erb docker_src, to: docker_dest, sudo: true
+    render_erb network_src, to: network_dest, sudo: true
     render_erb nginx_src, to: nginx_dest, sudo: true
     render_erb postgres_src, to: postgres_dest, sudo: true
   end

--- a/datadog/network.yaml.erb
+++ b/datadog/network.yaml.erb
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+  - collect_connection_state: true
+    excluded_interfaces:
+      - lo
+      - lo0


### PR DESCRIPTION
Does what it says, we've actually already shipped this to staging in order to test it, and we're already getting the new data from staging:

![screenshot at 2018-07-19 16-04-28](https://user-images.githubusercontent.com/2295892/42924417-6e252c44-8b6d-11e8-8ac2-8c1406e9d825.png)
