### PR TITLE
Disable buffering for the ShareJS endpoint

### DIFF
--- a/nginx/tc_vhost.common.erb
+++ b/nginx/tc_vhost.common.erb
@@ -28,7 +28,7 @@ location /sharejs/ {
   proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
 
   client_max_body_size  10m;
-  proxy_buffers         4 32k;
+  proxy_buffering       off;
 }
 
 # POSTs are intended for the app, not cached pages. We use '=' to let @app set the response code.


### PR DESCRIPTION
It might be worth disabling buffering for the `sharejs` endpoint. Most other example configurations for long-polling with nginx seem to disable it. I can't imagine why we would want to buffer the response from ShareJS, before passing it on to the client?

From the nginx docs:

> When buffering is disabled, the response is passed to a client synchronously, immediately as it is received. nginx will not try to read the whole response from the proxied server.