### PR TITLE
Add sharejs vhost

### DIFF
--- a/nginx/sharejs_vhost.conf.erb
+++ b/nginx/sharejs_vhost.conf.erb
@@ -1,0 +1,30 @@
+server {
+  charset utf-8;
+  server_name <%= domain %>;
+  listen 80;
+
+<% if enable_https[/^y/] %>
+  listen 443 ssl;
+
+  ssl_certificate      /etc/ssl/certs/<%= cert_name %>.pem;
+  ssl_certificate_key  /etc/ssl/private/<%= cert_name %>.key;
+  ssl_session_timeout  5m;
+  ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers          ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:HIGH:!aNULL:!MD5:!kEDH;
+  ssl_prefer_server_ciphers on;
+<% end %>
+
+  location / {
+    proxy_pass           http://127.0.0.1:<%= proxy_port %>;
+    proxy_redirect       off;
+
+    proxy_buffer_size    64k;
+    proxy_buffers        32 16k;
+
+    proxy_set_header     Host              $host;
+    proxy_set_header     Client-Ip         $tc_client_ip;
+    proxy_set_header     X-Real-IP         $remote_addr;
+    proxy_set_header     X-Forwarded-Proto $tc_client_scheme;
+    proxy_set_header     X-Request-Start   "t=${msec}";
+  }
+}

--- a/sharejs.rb
+++ b/sharejs.rb
@@ -3,9 +3,20 @@ dep "sharejs system", :app_user, :key, :env
 dep "sharejs env vars set", :domain
 
 dep "sharejs app", :env, :host, :domain, :app_user, :app_root, :key do
+  if env == 'production'
+    domain.default!('sharejs.theconversation.com')
+  else
+    domain.default!('sharejs.tc-dev.net')
+  end
+
   requires [
     "user exists".with(username: app_user),
-    "sharejs.systemd".with(app_user, env, app_root, "sharejs_#{env}")
+    "sharejs.systemd".with(app_user, env, app_root, "sharejs_#{env}"),
+    "proxy vhost enabled.nginx".with(
+      app_name: "sharejs",
+      domain: domain,
+      proxy_port: "9000"
+    )
   ]
 end
 


### PR DESCRIPTION
Does what it says, I discussed with @jameshill whether to do this quickly in babs or shift this over to ansible, and we figured it was better to do this in babs for now, but aim to move all the nginx config over to ansible when we have the time.

I've run this successfully on staging and it seems to work. Next I'll set up the cname config to bypass fastly and we should be good to go with our websockets test.
