### PR TITLE
Increase sharejs proxy timeout from default 60s to 1 hour

### DIFF
--- a/nginx/sharejs_vhost.conf.erb
+++ b/nginx/sharejs_vhost.conf.erb
@@ -23,6 +23,9 @@ server {
 
     proxy_http_version   1.1;
 
+    proxy_read_timeout   3600s;
+    proxy_send_timeout   3600s;
+
     proxy_set_header     Host              $host;
     proxy_set_header     Client-Ip         $tc_client_ip;
     proxy_set_header     X-Real-IP         $remote_addr;


### PR DESCRIPTION
Now nginx will only disconnect a client if it hasn't sent a frame for an hour, instead of the default 60 seconds.

Tested on staging and seems to work (no more 60 second disconnects).