### PR TITLE
Add a dep to run a data migration task

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -30,6 +30,15 @@ dep "migrated db", :username, :root, :env, :db_name, :deploying, template: "task
   end
 end
 
+dep "migrated data", :username, :root, :env, :db_name, :deploying, template: "task" do
+  root.default!(".")
+  deploying.default!("no")
+  requires "migrated db".with(username, root, env, db_name, "no")
+  run do
+    shell! "bundle exec rake data:migrate --trace RAILS_ENV=#{env} RACK_ENV=#{env}", cd: root, log: true
+  end
+end
+
 dep "schema loaded", :username, :root, :schema_path, :db_name do
   root.default!(".")
   schema_path.default!(root / "db/schema.sql")


### PR DESCRIPTION
Where we are using [data-migrate](https://github.com/ilyakatz/data-migrate), it would be good to be able to ensure a data migration ran, where applicable, on deploy.

This will be required for https://github.com/conversation/tc-donations/pull/817 and https://github.com/conversation/tc/pull/8971.