### PR TITLE
Stop unnecessarily requiring "migrated db" from "migrated data"

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -33,7 +33,6 @@ end
 dep "migrated data", :username, :root, :env, :db_name, :deploying, template: "task" do
   root.default!(".")
   deploying.default!("no")
-  requires "migrated db".with(username, root, env, db_name, "no")
   run do
     shell! "bundle exec rake data:migrate --trace RAILS_ENV=#{env} RACK_ENV=#{env}", cd: root, log: true
   end


### PR DESCRIPTION
When we do so, we can end up b0rking data migrations on deployment (see 'https://buildkite.com/conversation/legacy-deploy/builds/8093#09bcf724-f6a7-47cc-aa8b-8ff5764316f5/15-895'). It is fine to let the DB migration take care of itself in another dep.